### PR TITLE
Support simulated time

### DIFF
--- a/.github/workflows/rust_and_ros2.yml
+++ b/.github/workflows/rust_and_ros2.yml
@@ -17,7 +17,7 @@ jobs:
     - run: docker build . --file ./tests/Dockerfile_no_ros --tag r2r_no_ros
     - run: docker run r2r_no_ros cargo build --features doc-only
 
-  minimal_workspace_iron:
+  minimal_workspace_jazzy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -26,8 +26,15 @@ jobs:
       with:
         repository: m-dahl/r2r_minimal_node
         path: r2r_minimal_node
-    - run: docker build . --file ./tests/Dockerfile_iron --tag r2r_iron
-    - run: docker run r2r_iron /r2r/tests/build_minimal_node.bash
+    - run: docker build . --file ./tests/Dockerfile_jazzy --tag r2r_jazzy
+    - run: docker run r2r_jazzy /r2r/tests/build_minimal_node.bash
+
+  tests_jazzy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: docker build . --file ./tests/Dockerfile_jazzy --tag r2r_jazzy
+    - run: docker run r2r_jazzy cargo test
 
   tests_iron:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+- Add functions to destroy a publisher <https://github.com/sequenceplanner/r2r/pull/110>
 
 #### [0.9.2] - 2024-10-13
 - Fix cfg warnings <https://github.com/sequenceplanner/r2r/commit/4cb5bd362e81154924cc7dc21f8edbf470c4604a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These bindings are being written organically when things are needed by me and ot
 How to use
 --------------------
 1. Make sure you have libclang installed. (e.g. libclang-dev on ubuntu)
-2. Depend on this package in Cargo.toml: `r2r = "0.9.0"`
+2. Depend on this package in Cargo.toml: `r2r = "0.9.1"`
 3. You need to source your ROS2 installation before building/running.
 4. The bindings will rebuild automatically if/when you source your workspace(s).
 5. If you make changes to existing message types, run `cargo clean -p r2r_msg_gen` to force recompilation of the rust message types on the next build.
@@ -46,6 +46,9 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+
+#### [0.9.1] - 2024-10-12
+- Minor code fixes: <https://github.com/sequenceplanner/r2r/pull/105>, <https://github.com/sequenceplanner/r2r/pull/106>
 - Update for ros2 jazzy <https://github.com/sequenceplanner/r2r/pull/100>
 
 #### [0.9.0] - 2024-05-17

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+- Make the order of parameters deterministic <https://github.com/sequenceplanner/r2r/pull/94>
+- Add a r2r_info example to print environmental information <https://github.com/sequenceplanner/r2r/pull/92>
+- Code cleanups <https://github.com/sequenceplanner/r2r/pull/90>, <https://github.com/sequenceplanner/r2r/pull/91>
+- Remove is_available's node mut-ref dependency <https://github.com/sequenceplanner/r2r/pull/89>. Note, slight API change!
 - Support simulated time <https://github.com/sequenceplanner/r2r/pull/88>
 
 #### [0.8.4] - 2024-03-19

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These bindings are being written organically when things are needed by me and ot
 How to use
 --------------------
 1. Make sure you have libclang installed. (e.g. libclang-dev on ubuntu)
-2. Depend on this package in Cargo.toml: `r2r = "0.8.4"`
+2. Depend on this package in Cargo.toml: `r2r = "0.9.0"`
 3. You need to source your ROS2 installation before building/running.
 4. The bindings will rebuild automatically if/when you source your workspace(s).
 5. If you make changes to existing message types, run `cargo clean -p r2r_msg_gen` to force recompilation of the rust message types on the next build.
@@ -46,7 +46,10 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
-- Expose QoS settings for service clients and servers <https://github.com/sequenceplanner/r2r/pull/95>
+
+#### [0.9.0] - 2024-05-17
+- Fix unsafe precondition(s) violated with rust 1.78 <https://github.com/sequenceplanner/r2r/issues/96>. There may be more of these to fix, please report if you encounter.
+- Expose QoS settings for service clients and servers <https://github.com/sequenceplanner/r2r/pull/95>. Note, slight API change!
 - Make the order of parameters deterministic <https://github.com/sequenceplanner/r2r/pull/94>
 - Add a r2r_info example to print environmental information <https://github.com/sequenceplanner/r2r/pull/92>
 - Code cleanups <https://github.com/sequenceplanner/r2r/pull/90>, <https://github.com/sequenceplanner/r2r/pull/91>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+- Fix cfg warnings <https://github.com/sequenceplanner/r2r/commit/4cb5bd362e81154924cc7dc21f8edbf470c4604a>
+- More convinent one time parameter access <https://github.com/sequenceplanner/r2r/pull/107>
 
 #### [0.9.1] - 2024-10-12
 - Minor code fixes: <https://github.com/sequenceplanner/r2r/pull/105>, <https://github.com/sequenceplanner/r2r/pull/106>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+- Expose QoS settings for service clients and servers <https://github.com/sequenceplanner/r2r/pull/95>
 - Make the order of parameters deterministic <https://github.com/sequenceplanner/r2r/pull/94>
 - Add a r2r_info example to print environmental information <https://github.com/sequenceplanner/r2r/pull/92>
 - Code cleanups <https://github.com/sequenceplanner/r2r/pull/90>, <https://github.com/sequenceplanner/r2r/pull/91>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Since the default behavior is to build all sourced message types, build time can
 
 What works?
 --------------------
-- Up to date with ROS2 ~Dashing~ ~Eloquent~ Foxy Galactic Humble Iron
+- Up to date with ROS2 ~Dashing~ ~Eloquent~ Foxy Galactic Humble Iron Jazzy
 - Building Rust types
 - Publish/subscribe
 - Services
@@ -46,6 +46,7 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+- Update for ros2 jazzy <https://github.com/sequenceplanner/r2r/pull/100>
 
 #### [0.9.0] - 2024-05-17
 - Fix unsafe precondition(s) violated with rust 1.78 <https://github.com/sequenceplanner/r2r/issues/96>. There may be more of these to fix, please report if you encounter.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ What works?
 - Services
 - Actions
 - Parameter handling
+- Simulated time (make sure `rosgraph_msgs` is sourced when building to enable)
 - Runs on Linux, OSX, and Windows.
 
 Changelog
 --------------------
 #### [Unreleased]
+- Support simulated time <https://github.com/sequenceplanner/r2r/pull/88>
 
 #### [0.8.4] - 2024-03-19
 - Fix QoS for rolling <https://github.com/sequenceplanner/r2r/pull/87>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These bindings are being written organically when things are needed by me and ot
 How to use
 --------------------
 1. Make sure you have libclang installed. (e.g. libclang-dev on ubuntu)
-2. Depend on this package in Cargo.toml: `r2r = "0.9.3"`
+2. Depend on this package in Cargo.toml: `r2r = "0.9.4"`
 3. You need to source your ROS2 installation before building/running.
 4. The bindings will rebuild automatically if/when you source your workspace(s).
 5. If you make changes to existing message types, run `cargo clean -p r2r_msg_gen` to force recompilation of the rust message types on the next build.
@@ -46,6 +46,10 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+
+#### [0.9.4] - 2024-11-21
+- Fix cargo syntax for older rust versions < 1.77 <https://github.com/sequenceplanner/r2r/commit/74ad4410c79b1be7e42eb1822a291639e3c40ec4>
+- Fix message generation for WChar idl type <https://github.com/sequenceplanner/r2r/commit/94db799db282c8b1e0222f1699e6a6420b5fd544>
 
 #### [0.9.3] - 2024-11-09
 - Expose WrongParameterType <https://github.com/sequenceplanner/r2r/pull/111>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These bindings are being written organically when things are needed by me and ot
 How to use
 --------------------
 1. Make sure you have libclang installed. (e.g. libclang-dev on ubuntu)
-2. Depend on this package in Cargo.toml: `r2r = "0.9.1"`
+2. Depend on this package in Cargo.toml: `r2r = "0.9.2"`
 3. You need to source your ROS2 installation before building/running.
 4. The bindings will rebuild automatically if/when you source your workspace(s).
 5. If you make changes to existing message types, run `cargo clean -p r2r_msg_gen` to force recompilation of the rust message types on the next build.
@@ -46,6 +46,8 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+
+#### [0.9.2] - 2024-10-13
 - Fix cfg warnings <https://github.com/sequenceplanner/r2r/commit/4cb5bd362e81154924cc7dc21f8edbf470c4604a>
 - More convinent one time parameter access <https://github.com/sequenceplanner/r2r/pull/107>
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These bindings are being written organically when things are needed by me and ot
 How to use
 --------------------
 1. Make sure you have libclang installed. (e.g. libclang-dev on ubuntu)
-2. Depend on this package in Cargo.toml: `r2r = "0.8.3"`
+2. Depend on this package in Cargo.toml: `r2r = "0.8.4"`
 3. You need to source your ROS2 installation before building/running.
 4. The bindings will rebuild automatically if/when you source your workspace(s).
 5. If you make changes to existing message types, run `cargo clean -p r2r_msg_gen` to force recompilation of the rust message types on the next build.
@@ -45,6 +45,9 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+
+#### [0.8.4] - 2024-03-19
+- Fix QoS for rolling <https://github.com/sequenceplanner/r2r/pull/87>
 - Update for ros2 iron <https://github.com/sequenceplanner/r2r/pull/84>
 
 #### [0.8.3] - 2024-01-14

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These bindings are being written organically when things are needed by me and ot
 How to use
 --------------------
 1. Make sure you have libclang installed. (e.g. libclang-dev on ubuntu)
-2. Depend on this package in Cargo.toml: `r2r = "0.9.2"`
+2. Depend on this package in Cargo.toml: `r2r = "0.9.3"`
 3. You need to source your ROS2 installation before building/running.
 4. The bindings will rebuild automatically if/when you source your workspace(s).
 5. If you make changes to existing message types, run `cargo clean -p r2r_msg_gen` to force recompilation of the rust message types on the next build.
@@ -46,6 +46,9 @@ What works?
 Changelog
 --------------------
 #### [Unreleased]
+
+#### [0.9.3] - 2024-11-09
+- Expose WrongParameterType <https://github.com/sequenceplanner/r2r/pull/111>
 - Add functions to destroy a publisher <https://github.com/sequenceplanner/r2r/pull/110>
 
 #### [0.9.2] - 2024-10-13

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -49,6 +49,7 @@ prettyplease = "0.2.6"
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen", "r2r_actions/save-bindgen"]
 doc-only = ["r2r_common/doc-only", "r2r_rcl/doc-only", "r2r_msg_gen/doc-only", "r2r_actions/doc-only"]
+sim-time = []
 
 [package.metadata.docs.rs]
 features = ["doc-only"]

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -57,3 +57,7 @@ features = ["doc-only"]
 [[bench]]
 name = "deserialization"
 harness = false
+
+[[example]]
+name = "timer_sim_time"
+required-features = ["sim-time"]

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Easy to use, runtime-agnostic, async rust bindings for ROS2."
 license = "MIT AND Apache-2.0"
@@ -18,11 +18,11 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 lazy_static = "1.4.0"
-r2r_common = { path = "../r2r_common", version = "0.8.3" }
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.3" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.3" }
-r2r_actions = { path = "../r2r_actions", version = "0.8.3" }
-r2r_macros = { path = "../r2r_macros", version = "0.8.3" }
+r2r_common = { path = "../r2r_common", version = "0.8.4" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.4" }
+r2r_actions = { path = "../r2r_actions", version = "0.8.4" }
+r2r_macros = { path = "../r2r_macros", version = "0.8.4" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 futures = "0.3.25"
 log = "0.4.18"
@@ -37,8 +37,8 @@ cdr = "0.2.4"
 criterion = "0.5.1"
 
 [build-dependencies]
-r2r_common = { path = "../r2r_common", version = "0.8.3" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.3" }
+r2r_common = { path = "../r2r_common", version = "0.8.4" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.4" }
 rayon = "1.7.0"
 force-send-sync = "1.0.0"
 quote = "1.0.28"

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { version = "1.2.2", features = ["serde", "v4"] }
 futures = "0.3.25"
 log = "0.4.18"
 phf = "0.11.1"
+indexmap = "2.2.6"
 
 [dev-dependencies]
 serde_json = "1.0.89"

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Easy to use, runtime-agnostic, async rust bindings for ROS2."
 license = "MIT AND Apache-2.0"
@@ -18,11 +18,11 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 lazy_static = "1.4.0"
-r2r_common = { path = "../r2r_common", version = "0.9.1" }
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.1" }
-r2r_actions = { path = "../r2r_actions", version = "0.9.1" }
-r2r_macros = { path = "../r2r_macros", version = "0.9.1" }
+r2r_common = { path = "../r2r_common", version = "0.9.2" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.2" }
+r2r_actions = { path = "../r2r_actions", version = "0.9.2" }
+r2r_macros = { path = "../r2r_macros", version = "0.9.2" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 futures = "0.3.25"
 log = "0.4.18"
@@ -38,8 +38,8 @@ cdr = "0.2.4"
 criterion = "0.5.1"
 
 [build-dependencies]
-r2r_common = { path = "../r2r_common", version = "0.9.1" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.1" }
+r2r_common = { path = "../r2r_common", version = "0.9.2" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.2" }
 rayon = "1.7.0"
 force-send-sync = "1.0.0"
 quote = "1.0.28"

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Easy to use, runtime-agnostic, async rust bindings for ROS2."
 license = "MIT AND Apache-2.0"
@@ -18,11 +18,11 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 lazy_static = "1.4.0"
-r2r_common = { path = "../r2r_common", version = "0.9.2" }
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.2" }
-r2r_actions = { path = "../r2r_actions", version = "0.9.2" }
-r2r_macros = { path = "../r2r_macros", version = "0.9.2" }
+r2r_common = { path = "../r2r_common", version = "0.9.3" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.3" }
+r2r_actions = { path = "../r2r_actions", version = "0.9.3" }
+r2r_macros = { path = "../r2r_macros", version = "0.9.3" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 futures = "0.3.25"
 log = "0.4.18"
@@ -38,8 +38,8 @@ cdr = "0.2.4"
 criterion = "0.5.1"
 
 [build-dependencies]
-r2r_common = { path = "../r2r_common", version = "0.9.2" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.2" }
+r2r_common = { path = "../r2r_common", version = "0.9.3" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.3" }
 rayon = "1.7.0"
 force-send-sync = "1.0.0"
 quote = "1.0.28"

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Easy to use, runtime-agnostic, async rust bindings for ROS2."
 license = "MIT AND Apache-2.0"
@@ -18,11 +18,11 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 lazy_static = "1.4.0"
-r2r_common = { path = "../r2r_common", version = "0.9.0" }
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.0" }
-r2r_actions = { path = "../r2r_actions", version = "0.9.0" }
-r2r_macros = { path = "../r2r_macros", version = "0.9.0" }
+r2r_common = { path = "../r2r_common", version = "0.9.1" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.1" }
+r2r_actions = { path = "../r2r_actions", version = "0.9.1" }
+r2r_macros = { path = "../r2r_macros", version = "0.9.1" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 futures = "0.3.25"
 log = "0.4.18"
@@ -38,8 +38,8 @@ cdr = "0.2.4"
 criterion = "0.5.1"
 
 [build-dependencies]
-r2r_common = { path = "../r2r_common", version = "0.9.0" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.0" }
+r2r_common = { path = "../r2r_common", version = "0.9.1" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.1" }
 rayon = "1.7.0"
 force-send-sync = "1.0.0"
 quote = "1.0.28"

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Easy to use, runtime-agnostic, async rust bindings for ROS2."
 license = "MIT AND Apache-2.0"
@@ -18,11 +18,11 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 lazy_static = "1.4.0"
-r2r_common = { path = "../r2r_common", version = "0.9.3" }
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.3" }
-r2r_actions = { path = "../r2r_actions", version = "0.9.3" }
-r2r_macros = { path = "../r2r_macros", version = "0.9.3" }
+r2r_common = { path = "../r2r_common", version = "0.9.4" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.4" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.4" }
+r2r_actions = { path = "../r2r_actions", version = "0.9.4" }
+r2r_macros = { path = "../r2r_macros", version = "0.9.4" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 futures = "0.3.25"
 log = "0.4.18"
@@ -38,8 +38,8 @@ cdr = "0.2.4"
 criterion = "0.5.1"
 
 [build-dependencies]
-r2r_common = { path = "../r2r_common", version = "0.9.3" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.3" }
+r2r_common = { path = "../r2r_common", version = "0.9.4" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.4" }
 rayon = "1.7.0"
 force-send-sync = "1.0.0"
 quote = "1.0.28"

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -49,7 +49,6 @@ prettyplease = "0.2.6"
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen", "r2r_actions/save-bindgen"]
 doc-only = ["r2r_common/doc-only", "r2r_rcl/doc-only", "r2r_msg_gen/doc-only", "r2r_actions/doc-only"]
-sim-time = []
 
 [package.metadata.docs.rs]
 features = ["doc-only"]
@@ -57,7 +56,3 @@ features = ["doc-only"]
 [[bench]]
 name = "deserialization"
 harness = false
-
-[[example]]
-name = "timer_sim_time"
-required-features = ["sim-time"]

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Easy to use, runtime-agnostic, async rust bindings for ROS2."
 license = "MIT AND Apache-2.0"
@@ -18,11 +18,11 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 lazy_static = "1.4.0"
-r2r_common = { path = "../r2r_common", version = "0.8.4" }
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.4" }
-r2r_actions = { path = "../r2r_actions", version = "0.8.4" }
-r2r_macros = { path = "../r2r_macros", version = "0.8.4" }
+r2r_common = { path = "../r2r_common", version = "0.9.0" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.0" }
+r2r_actions = { path = "../r2r_actions", version = "0.9.0" }
+r2r_macros = { path = "../r2r_macros", version = "0.9.0" }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 futures = "0.3.25"
 log = "0.4.18"
@@ -38,8 +38,8 @@ cdr = "0.2.4"
 criterion = "0.5.1"
 
 [build-dependencies]
-r2r_common = { path = "../r2r_common", version = "0.8.4" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.4" }
+r2r_common = { path = "../r2r_common", version = "0.9.0" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.0" }
 rayon = "1.7.0"
 force-send-sync = "1.0.0"
 quote = "1.0.28"

--- a/r2r/benches/deserialization.rs
+++ b/r2r/benches/deserialization.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use r2r::*;
-use rand::thread_rng;
-use rand::Rng;
+use rand::{thread_rng, Rng};
 
 const NUM_ELEMENTS: usize = 10_000;
 const NUM_TIMES: usize = 1_000;

--- a/r2r/build.rs
+++ b/r2r/build.rs
@@ -7,8 +7,10 @@ use {
     std::io::{self, prelude::*, BufWriter},
 };
 
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 #[cfg(feature = "doc-only")]
 mod filenames {

--- a/r2r/build.rs
+++ b/r2r/build.rs
@@ -102,7 +102,7 @@ fn generate_bindings(bindgen_dir: &Path) {
         };
 
         let msgs_file = bindgen_dir.join(MSGS_FILENAME);
-        write_to_file(&msgs_file, &pretty_tokenstream(modules)).unwrap();
+        write_to_file(&msgs_file, pretty_tokenstream(modules)).unwrap();
     }
 
     let mod_files: Vec<_> = msgs
@@ -113,7 +113,7 @@ fn generate_bindings(bindgen_dir: &Path) {
                 .map(|(prefix, msgs)| {
                     let prefix_content = match *prefix {
                         "msg" => {
-                            let msg_snipplets = msgs.into_iter().map(|msg| {
+                            let msg_snipplets = msgs.iter().map(|msg| {
                                 println!("cargo:rustc-cfg=r2r__{}__{}__{}", module, prefix, msg);
                                 r2r_msg_gen::generate_rust_msg(module, prefix, msg)
                             });
@@ -124,7 +124,7 @@ fn generate_bindings(bindgen_dir: &Path) {
                             }
                         }
                         "srv" => {
-                            let msg_snipplets = msgs.into_iter().map(|msg| {
+                            let msg_snipplets = msgs.iter().map(|msg| {
                                 let service_snipplet =
                                     r2r_msg_gen::generate_rust_service(module, prefix, msg);
                                 let msg_snipplets = ["Request", "Response"].iter().map(|s| {
@@ -152,7 +152,7 @@ fn generate_bindings(bindgen_dir: &Path) {
                             }
                         }
                         "action" => {
-                            let msg_snipplets = msgs.into_iter().map(|msg| {
+                            let msg_snipplets = msgs.iter().map(|msg| {
                                 let action_snipplet =
                                     r2r_msg_gen::generate_rust_action(module, prefix, msg);
 
@@ -241,7 +241,7 @@ fn generate_bindings(bindgen_dir: &Path) {
             let mod_content = quote! { #(#snipplets)* };
             let file_name = format!("{}.rs", module);
             let mod_file = bindgen_dir.join(&file_name);
-            write_to_file(&mod_file, &pretty_tokenstream(mod_content)).unwrap();
+            write_to_file(&mod_file, pretty_tokenstream(mod_content)).unwrap();
 
             file_name
         })
@@ -251,19 +251,19 @@ fn generate_bindings(bindgen_dir: &Path) {
     {
         let untyped_helper = r2r_msg_gen::generate_untyped_helper(&msg_list);
         let untyped_file = bindgen_dir.join(UNTYPED_FILENAME);
-        write_to_file(&untyped_file, &pretty_tokenstream(untyped_helper)).unwrap();
+        write_to_file(&untyped_file, pretty_tokenstream(untyped_helper)).unwrap();
     }
 
     {
         let untyped_service_helper = r2r_msg_gen::generate_untyped_service_helper(&msg_list);
         let untyped_service_file = bindgen_dir.join(UNTYPED_SERVICE_FILENAME);
-        write_to_file(&untyped_service_file, &pretty_tokenstream(untyped_service_helper)).unwrap();
+        write_to_file(&untyped_service_file, pretty_tokenstream(untyped_service_helper)).unwrap();
     }
 
     {
         let untyped_action_helper = r2r_msg_gen::generate_untyped_action_helper(&msg_list);
         let untyped_action_file = bindgen_dir.join(UNTYPED_ACTION_FILENAME);
-        write_to_file(&untyped_action_file, &pretty_tokenstream(untyped_action_helper)).unwrap();
+        write_to_file(&untyped_action_file, pretty_tokenstream(untyped_action_helper)).unwrap();
     }
 
     // Save file list
@@ -292,16 +292,17 @@ fn copy_files(src_dir: &Path, tgt_dir: &Path) {
         .for_each(|file_name| {
             let src_file = src_dir.join(file_name);
             let tgt_file = tgt_dir.join(file_name);
-            fs::copy(&src_file, &tgt_file).unwrap();
+            fs::copy(src_file, tgt_file).unwrap();
         });
 
-    fs::copy(&src_list_file, &tgt_list_file).unwrap();
+    fs::copy(&src_list_file, tgt_list_file).unwrap();
 }
 
 #[cfg(not(feature = "doc-only"))]
 fn touch(path: &Path) {
     OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(path)
         .unwrap_or_else(|_| panic!("Unable to create file '{}'", path.display()));

--- a/r2r/build.rs
+++ b/r2r/build.rs
@@ -36,6 +36,18 @@ use filenames::*;
 
 fn main() {
     r2r_common::print_cargo_watches();
+    // Declare all the custom cfg directives we use
+    // to silence cargo warnings.
+    r2r_common::print_cargo_used_cfgs(&[
+        "r2r__rosgraph_msgs__msg__Clock",
+        "r2r__action_msgs__msg__GoalStatus",
+        "r2r__test_msgs__msg__Defaults",
+        "r2r__test_msgs__msg__Arrays",
+        "r2r__test_msgs__msg__WStrings",
+        "r2r__example_interfaces__srv__AddTwoInts",
+        "r2r__std_srvs__srv__Empty",
+        "r2r__example_interfaces__action__Fibonacci",
+    ]);
     r2r_common::print_cargo_ros_distro();
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/r2r/examples/action_client.rs
+++ b/r2r/examples/action_client.rs
@@ -1,7 +1,4 @@
-use futures::executor::LocalPool;
-use futures::future::FutureExt;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future::FutureExt, stream::StreamExt, task::LocalSpawnExt};
 
 use r2r::example_interfaces::action::Fibonacci;
 use std::sync::{Arc, Mutex};

--- a/r2r/examples/action_client.rs
+++ b/r2r/examples/action_client.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
     let client = node.create_action_client::<Fibonacci::Action>("/fibonacci")?;
-    let action_server_available = node.is_available(&client)?;
+    let action_server_available = r2r::Node::is_available(&client)?;
 
     // signal that we are done
     let done = Arc::new(Mutex::new(false));

--- a/r2r/examples/action_client_untyped.rs
+++ b/r2r/examples/action_client_untyped.rs
@@ -1,10 +1,7 @@
 //
 // This example is the same as action_client.rs but stripped of all (explicit) type information.
 //
-use futures::executor::LocalPool;
-use futures::future::FutureExt;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future::FutureExt, stream::StreamExt, task::LocalSpawnExt};
 
 use std::sync::{Arc, Mutex};
 

--- a/r2r/examples/action_client_untyped.rs
+++ b/r2r/examples/action_client_untyped.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
     let client =
         node.create_action_client_untyped("/fibonacci", "example_interfaces/action/Fibonacci")?;
-    let action_server_available = node.is_available(&client)?;
+    let action_server_available = r2r::Node::is_available(&client)?;
 
     // signal that we are done
     let done = Arc::new(Mutex::new(false));

--- a/r2r/examples/action_server.rs
+++ b/r2r/examples/action_server.rs
@@ -1,7 +1,9 @@
-use futures::executor::{LocalPool, LocalSpawner};
-use futures::future::{self, Either};
-use futures::stream::{Stream, StreamExt};
-use futures::task::LocalSpawnExt;
+use futures::{
+    executor::{LocalPool, LocalSpawner},
+    future::{self, Either},
+    stream::{Stream, StreamExt},
+    task::LocalSpawnExt,
+};
 
 use r2r::example_interfaces::action::Fibonacci;
 use std::sync::{Arc, Mutex};

--- a/r2r/examples/client.rs
+++ b/r2r/examples/client.rs
@@ -29,7 +29,8 @@ async fn requester_task(
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
-    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
+    let client =
+        node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
 
     let service_available = r2r::Node::is_available(&client)?;
 

--- a/r2r/examples/client.rs
+++ b/r2r/examples/client.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
     let client = node.create_client::<AddTwoInts::Service>("/add_two_ints")?;
 
-    let service_available = node.is_available(&client)?;
+    let service_available = r2r::Node::is_available(&client)?;
 
     let mut pool = LocalPool::new();
     let spawner = pool.spawner();

--- a/r2r/examples/client.rs
+++ b/r2r/examples/client.rs
@@ -2,7 +2,7 @@ use futures::{executor::LocalPool, task::LocalSpawnExt, Future};
 
 use std::io::Write;
 
-use r2r::example_interfaces::srv::AddTwoInts;
+use r2r::{example_interfaces::srv::AddTwoInts, QosProfile};
 
 async fn requester_task(
     node_available: impl Future<Output = r2r::Result<()>>, c: r2r::Client<AddTwoInts::Service>,
@@ -29,7 +29,7 @@ async fn requester_task(
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
-    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints")?;
+    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
 
     let service_available = r2r::Node::is_available(&client)?;
 

--- a/r2r/examples/client.rs
+++ b/r2r/examples/client.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
-use futures::Future;
+use futures::{executor::LocalPool, task::LocalSpawnExt, Future};
 
 use std::io::Write;
 

--- a/r2r/examples/parameters.rs
+++ b/r2r/examples/parameters.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::prelude::*;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, prelude::*, task::LocalSpawnExt};
 
 // try to run like this
 // cargo run --example parameters -- --ros-args -p key1:=[hello,world] -p key2:=5.5 -r __ns:=/demo -r __node:=my_node

--- a/r2r/examples/parameters.rs
+++ b/r2r/examples/parameters.rs
@@ -18,6 +18,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "to_be_replaced", "to_be_replaced")?;
 
+    // if you only need to load a parameter once at startup, it can be done like this.
+    // errors can be propigated with the ? operator and enhanced with the `thiserror` and `anyhow` crates.
+    // we do not use the ? operator here because we want the program to continue, even if the value is not set.
+    let serial_interface_path = node.get_parameter::<String>("serial_interface");
+    match serial_interface_path {
+        Ok(serial_interface) => println!("Serial interface: {serial_interface}"),
+        Err(error) => println!("Failed to get name of serial interface: {error}"),
+    }
+
+    // you can also get parameters as optional types.
+    // this will be None if the parameter is not set. If the parameter is set but to the wrong type, this will
+    // will produce an error.
+    let baud_rate: Option<i64> = node.get_parameter("baud_rate")?;
+
+    // because the baud_rate is an optional type, we can use `unwrap_or` to provide a default value.
+    let baud_rate = baud_rate.unwrap_or(115200);
+    println!("Baud rate: {baud_rate}");
+
     // make a parameter handler (once per node).
     // the parameter handler is optional, only spawn one if you need it.
     let (paramater_handler, parameter_events) = node.make_parameter_handler()?;

--- a/r2r/examples/parameters_derive.rs
+++ b/r2r/examples/parameters_derive.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::prelude::*;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, prelude::*, task::LocalSpawnExt};
 use r2r::RosParams;
 use std::sync::{Arc, Mutex};
 

--- a/r2r/examples/publishers.rs
+++ b/r2r/examples/publishers.rs
@@ -1,7 +1,6 @@
-use r2r::builtin_interfaces::msg::Duration;
-use r2r::std_msgs::msg::Int32;
-use r2r::trajectory_msgs::msg::*;
-use r2r::QosProfile;
+use r2r::{
+    builtin_interfaces::msg::Duration, std_msgs::msg::Int32, trajectory_msgs::msg::*, QosProfile,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;

--- a/r2r/examples/publishers.rs
+++ b/r2r/examples/publishers.rs
@@ -31,6 +31,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         count += 1;
     }
 
+    // destroy publisher before the node
+    node.destroy_publisher(publisher);
+
     println!("All done!");
 
     Ok(())

--- a/r2r/examples/rostopic_echo.rs
+++ b/r2r/examples/rostopic_echo.rs
@@ -1,12 +1,7 @@
-use futures::executor::LocalPool;
-use futures::future;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future, stream::StreamExt, task::LocalSpawnExt};
 use r2r::QosProfile;
 
-use std::collections::HashMap;
-use std::env;
-use std::thread;
+use std::{collections::HashMap, env, thread};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;

--- a/r2r/examples/rostopic_list.rs
+++ b/r2r/examples/rostopic_list.rs
@@ -1,5 +1,4 @@
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;

--- a/r2r/examples/service.rs
+++ b/r2r/examples/service.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut timer = node.create_wall_timer(std::time::Duration::from_millis(250))?;
     let mut timer2 = node.create_wall_timer(std::time::Duration::from_millis(2000))?;
     // wait for service to be available
-    let service_available = node.is_available(&client)?;
+    let service_available = r2r::Node::is_available(&client)?;
     let mut pool = LocalPool::new();
     let spawner = pool.spawner();
 

--- a/r2r/examples/service.rs
+++ b/r2r/examples/service.rs
@@ -1,8 +1,4 @@
-use futures::executor::LocalPool;
-use futures::select;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
-use futures::FutureExt;
+use futures::{executor::LocalPool, select, stream::StreamExt, task::LocalSpawnExt, FutureExt};
 
 use r2r::example_interfaces::srv::AddTwoInts;
 
@@ -12,7 +8,6 @@ use r2r::example_interfaces::srv::AddTwoInts;
 /// Run toghtether with the client example.
 /// e.g. cargo run --example service
 /// and in another terminal cargo run --example client
-///
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;

--- a/r2r/examples/service.rs
+++ b/r2r/examples/service.rs
@@ -1,6 +1,6 @@
 use futures::{executor::LocalPool, select, stream::StreamExt, task::LocalSpawnExt, FutureExt};
 
-use r2r::example_interfaces::srv::AddTwoInts;
+use r2r::{example_interfaces::srv::AddTwoInts, QosProfile};
 
 ///
 /// This example demonstrates how we can chain async service calls.
@@ -11,9 +11,9 @@ use r2r::example_interfaces::srv::AddTwoInts;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
-    let mut service = node.create_service::<AddTwoInts::Service>("/add_two_ints")?;
-    let service_delayed = node.create_service::<AddTwoInts::Service>("/add_two_ints_delayed")?;
-    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints_delayed")?;
+    let mut service = node.create_service::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
+    let service_delayed = node.create_service::<AddTwoInts::Service>("/add_two_ints_delayed", QosProfile::default())?;
+    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints_delayed", QosProfile::default())?;
     let mut timer = node.create_wall_timer(std::time::Duration::from_millis(250))?;
     let mut timer2 = node.create_wall_timer(std::time::Duration::from_millis(2000))?;
     // wait for service to be available

--- a/r2r/examples/service.rs
+++ b/r2r/examples/service.rs
@@ -11,9 +11,12 @@ use r2r::{example_interfaces::srv::AddTwoInts, QosProfile};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
-    let mut service = node.create_service::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
-    let service_delayed = node.create_service::<AddTwoInts::Service>("/add_two_ints_delayed", QosProfile::default())?;
-    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints_delayed", QosProfile::default())?;
+    let mut service =
+        node.create_service::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
+    let service_delayed =
+        node.create_service::<AddTwoInts::Service>("/add_two_ints_delayed", QosProfile::default())?;
+    let client =
+        node.create_client::<AddTwoInts::Service>("/add_two_ints_delayed", QosProfile::default())?;
     let mut timer = node.create_wall_timer(std::time::Duration::from_millis(250))?;
     let mut timer2 = node.create_wall_timer(std::time::Duration::from_millis(2000))?;
     // wait for service to be available

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -1,0 +1,30 @@
+use r2r::rosgraph_msgs::msg;
+use r2r::ClockType::SystemTime;
+use r2r::{Clock, QosProfile};
+use std::time::Duration;
+
+/// Simple publisher publishing time starting at time 0 every `SENDING_PERIOD`
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = r2r::Context::create()?;
+    let mut node = r2r::Node::create(ctx, "clock_publisher", "")?;
+    let qos = QosProfile::default().keep_last(1);
+    let publisher = node.create_publisher("/clock", qos)?;
+
+    const SENDING_PERIOD: Duration = Duration::from_millis(100);
+    const SIM_TIME_MULTIPLIER: f64 = 0.1;
+
+    let mut clock = Clock::create(SystemTime)?;
+    let zero_time = clock.get_now()?;
+    let mut msg = msg::Clock::default();
+
+    loop {
+        let time_diff = clock.get_now()? - zero_time;
+        let time = time_diff.mul_f64(SIM_TIME_MULTIPLIER);
+        msg.clock = Clock::to_builtin_time(&time);
+
+        publisher.publish(&msg)?;
+        println!("Publishing time {}.{:9} s", time.as_secs(), time.subsec_nanos());
+
+        std::thread::sleep(SENDING_PERIOD);
+    }
+}

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -1,10 +1,11 @@
-use r2r::rosgraph_msgs::msg;
 use r2r::ClockType::SystemTime;
 use r2r::{Clock, QosProfile};
 use std::time::Duration;
 
 /// Simple publisher publishing time starting at time 0 every `SENDING_PERIOD`
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use r2r::rosgraph_msgs::msg;
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "clock_publisher", "")?;
     let qos = QosProfile::default().keep_last(1);
@@ -27,4 +28,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         std::thread::sleep(SENDING_PERIOD);
     }
+}
+
+#[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
+fn main() {
 }

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -32,4 +32,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
 fn main() {
+    panic!("Sim_time_publisher example is not compiled with 'rosgraph_msgs'.");
 }

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -1,5 +1,4 @@
-use r2r::ClockType::SystemTime;
-use r2r::{Clock, QosProfile};
+use r2r::{Clock, ClockType::SystemTime, QosProfile};
 use std::time::Duration;
 
 /// Simple publisher publishing time starting at time 0 every `SENDING_PERIOD`

--- a/r2r/examples/subscriber.rs
+++ b/r2r/examples/subscriber.rs
@@ -1,7 +1,4 @@
-use futures::executor::LocalPool;
-use futures::future;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future, stream::StreamExt, task::LocalSpawnExt};
 use r2r::QosProfile;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -1,0 +1,82 @@
+use futures::executor::LocalPool;
+use futures::task::LocalSpawnExt;
+
+use r2r::{Clock, ClockType};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+async fn timer_task(
+    mut t: r2r::Timer, ros_clock: Arc<Mutex<Clock>>, mut system_clock: Clock,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut iteration: i32 = 0;
+    loop {
+        let elapsed = t.tick().await?;
+
+        let ros_time = ros_clock.lock().unwrap().get_now()?;
+        let system_time = system_clock.get_now()?;
+
+        println!("Timer called ({}), {}us since last call", iteration, elapsed.as_micros());
+        println!(
+            "\tcurrent time ros={:.3}s, system={:.3}s",
+            ros_time.as_secs_f64(),
+            system_time.as_secs_f64()
+        );
+
+        iteration += 1;
+        if iteration == 10 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Publication of time can be done either using the example `sim_time_publisher`
+/// or with `ros2 bag play --clock <clock_frequency> <the_bag>`
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = r2r::Context::create()?;
+    let mut node = r2r::Node::create(ctx, "testnode", "")?;
+
+    let mut pool = LocalPool::new();
+    let spawner = pool.spawner();
+
+    // Simulated time can be enabled by registering parameter handler
+    // and starting the program this ros param 'use_sim_time:=true'
+    // ```shell
+    // cargo run --features=sim-time --example=timer_sim_time -- --ros-args -p use_sim_time:=true
+    // ```
+    // this does not work if the parameter is changed during the runtime
+    let (paramater_handler, _parameter_events) = node.make_parameter_handler()?;
+    spawner.spawn_local(paramater_handler)?;
+
+    // or simulated time can be enabled/disabled directly by calling these functions:
+    // let time_source = node.get_time_source();
+    // time_source.enable_sim_time(&mut node)?;
+    // time_source.disable_sim_time();
+
+    // Note: Wall timer does not use sim time
+    let timer = node.create_timer(std::time::Duration::from_millis(1000))?;
+
+    let is_done = Rc::new(RefCell::new(false));
+
+    let task_is_done = is_done.clone();
+    let ros_clock = node.get_ros_clock();
+    let system_clock = Clock::create(ClockType::SystemTime)?;
+    spawner.spawn_local(async move {
+        match timer_task(timer, ros_clock, system_clock).await {
+            Ok(()) => {
+                *task_is_done.borrow_mut() = true;
+                println!("exiting");
+            }
+            Err(e) => println!("error: {}", e),
+        }
+    })?;
+
+    while !*is_done.borrow() {
+        node.spin_once(std::time::Duration::from_millis(100));
+
+        pool.run_until_stalled();
+    }
+
+    Ok(())
+}

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -33,6 +33,7 @@ async fn timer_task(
 
 /// Publication of time can be done either using the example `sim_time_publisher`
 /// or with `ros2 bag play --clock <clock_frequency> <the_bag>`
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
@@ -79,4 +80,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
+fn main() {
+    panic!("Timer_sim_time example is not compiled with 'rosgraph_msgs'.");
 }

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -1,10 +1,11 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, task::LocalSpawnExt};
 
 use r2r::{Clock, ClockType};
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 
 async fn timer_task(
     mut t: r2r::Timer, ros_clock: Arc<Mutex<Clock>>, mut system_clock: Clock,

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Simulated time can be enabled by registering parameter handler
     // and starting the program this ros param 'use_sim_time:=true'
     // ```shell
-    // cargo run --features=sim-time --example=timer_sim_time -- --ros-args -p use_sim_time:=true
+    // cargo run --example=timer_sim_time -- --ros-args -p use_sim_time:=true
     // ```
     // this does not work if the parameter is changed during the runtime
     let (paramater_handler, _parameter_events) = node.make_parameter_handler()?;

--- a/r2r/examples/tokio.rs
+++ b/r2r/examples/tokio.rs
@@ -1,5 +1,4 @@
-use futures::future;
-use futures::stream::StreamExt;
+use futures::{future, stream::StreamExt};
 use r2r::QosProfile;
 
 use std::sync::{Arc, Mutex};

--- a/r2r/examples/tokio_client.rs
+++ b/r2r/examples/tokio_client.rs
@@ -7,7 +7,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let duration = std::time::Duration::from_millis(2500);
 
     use r2r::example_interfaces::srv::AddTwoInts;
-    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
+    let client =
+        node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
     let mut timer = node.create_wall_timer(duration)?;
     let waiting = r2r::Node::is_available(&client)?;
 

--- a/r2r/examples/tokio_client.rs
+++ b/r2r/examples/tokio_client.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use r2r::example_interfaces::srv::AddTwoInts;
     let client = node.create_client::<AddTwoInts::Service>("/add_two_ints")?;
     let mut timer = node.create_wall_timer(duration)?;
-    let waiting = node.is_available(&client)?;
+    let waiting = r2r::Node::is_available(&client)?;
 
     let handle = tokio::task::spawn_blocking(move || loop {
         node.spin_once(std::time::Duration::from_millis(100));

--- a/r2r/examples/tokio_client.rs
+++ b/r2r/examples/tokio_client.rs
@@ -1,3 +1,5 @@
+use r2r::QosProfile;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
@@ -5,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let duration = std::time::Duration::from_millis(2500);
 
     use r2r::example_interfaces::srv::AddTwoInts;
-    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints")?;
+    let client = node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
     let mut timer = node.create_wall_timer(duration)?;
     let waiting = r2r::Node::is_available(&client)?;
 

--- a/r2r/examples/tokio_examples.rs
+++ b/r2r/examples/tokio_examples.rs
@@ -75,7 +75,8 @@ async fn client(arc_node: Arc<Mutex<r2r::Node>>) -> Result<(), r2r::Error> {
     let (client, mut timer, service_available) = {
         // Limiting the scope when locking the arc
         let mut node = arc_node.lock().unwrap();
-        let client = node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
+        let client =
+            node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
         let timer = node.create_wall_timer(std::time::Duration::from_secs(2))?;
         let service_available = r2r::Node::is_available(&client)?;
         (client, timer, service_available)

--- a/r2r/examples/tokio_examples.rs
+++ b/r2r/examples/tokio_examples.rs
@@ -78,7 +78,7 @@ async fn client(arc_node: Arc<Mutex<r2r::Node>>) -> Result<(), r2r::Error> {
         let mut node = arc_node.lock().unwrap();
         let client = node.create_client::<AddTwoInts::Service>("/add_two_ints")?;
         let timer = node.create_wall_timer(std::time::Duration::from_secs(2))?;
-        let service_available = node.is_available(&client)?;
+        let service_available = r2r::Node::is_available(&client)?;
         (client, timer, service_available)
     };
     println!("waiting for service...");

--- a/r2r/examples/tokio_examples.rs
+++ b/r2r/examples/tokio_examples.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use futures::future;
-use futures::stream::StreamExt;
+use futures::{future, stream::StreamExt};
 
 use r2r::QosProfile;
 use tokio::task;

--- a/r2r/examples/tokio_examples.rs
+++ b/r2r/examples/tokio_examples.rs
@@ -75,7 +75,7 @@ async fn client(arc_node: Arc<Mutex<r2r::Node>>) -> Result<(), r2r::Error> {
     let (client, mut timer, service_available) = {
         // Limiting the scope when locking the arc
         let mut node = arc_node.lock().unwrap();
-        let client = node.create_client::<AddTwoInts::Service>("/add_two_ints")?;
+        let client = node.create_client::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
         let timer = node.create_wall_timer(std::time::Duration::from_secs(2))?;
         let service_available = r2r::Node::is_available(&client)?;
         (client, timer, service_available)
@@ -98,7 +98,7 @@ async fn service(arc_node: Arc<Mutex<r2r::Node>>) -> Result<(), r2r::Error> {
     let mut service = {
         // Limiting the scope when locking the arc
         let mut node = arc_node.lock().unwrap();
-        node.create_service::<AddTwoInts::Service>("/add_two_ints")?
+        node.create_service::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?
     };
     loop {
         match service.next().await {

--- a/r2r/examples/tokio_raw_publisher.rs
+++ b/r2r/examples/tokio_raw_publisher.rs
@@ -1,5 +1,4 @@
-use r2r::QosProfile;
-use r2r::WrappedTypesupport;
+use r2r::{QosProfile, WrappedTypesupport};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/r2r/examples/tokio_raw_subscriber.rs
+++ b/r2r/examples/tokio_raw_subscriber.rs
@@ -1,7 +1,5 @@
-use futures::future;
-use futures::stream::StreamExt;
-use r2r::QosProfile;
-use r2r::WrappedTypesupport;
+use futures::{future, stream::StreamExt};
+use r2r::{QosProfile, WrappedTypesupport};
 use serde::{Deserialize, Serialize};
 
 #[tokio::main]

--- a/r2r/examples/tokio_service.rs
+++ b/r2r/examples/tokio_service.rs
@@ -1,4 +1,5 @@
 use futures::stream::StreamExt;
+use r2r::QosProfile;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -6,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
 
     use r2r::example_interfaces::srv::AddTwoInts;
-    let mut service = node.create_service::<AddTwoInts::Service>("/add_two_ints")?;
+    let mut service = node.create_service::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
 
     let handle = tokio::task::spawn_blocking(move || loop {
         node.spin_once(std::time::Duration::from_millis(100));

--- a/r2r/examples/tokio_service.rs
+++ b/r2r/examples/tokio_service.rs
@@ -7,7 +7,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
 
     use r2r::example_interfaces::srv::AddTwoInts;
-    let mut service = node.create_service::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
+    let mut service =
+        node.create_service::<AddTwoInts::Service>("/add_two_ints", QosProfile::default())?;
 
     let handle = tokio::task::spawn_blocking(move || loop {
         node.spin_once(std::time::Duration::from_millis(100));

--- a/r2r/examples/tokio_subscriber.rs
+++ b/r2r/examples/tokio_subscriber.rs
@@ -1,5 +1,4 @@
-use futures::future;
-use futures::stream::StreamExt;
+use futures::{future, stream::StreamExt};
 use r2r::QosProfile;
 
 #[tokio::main]

--- a/r2r/examples/untyped_client.rs
+++ b/r2r/examples/untyped_client.rs
@@ -1,4 +1,5 @@
 use futures::{executor::LocalPool, task::LocalSpawnExt, Future};
+use r2r::QosProfile;
 
 async fn requester_task(
     node_available: impl Future<Output = r2r::Result<()>>, c: r2r::ClientUntyped,
@@ -25,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
     let client =
-        node.create_client_untyped("/add_two_ints", "example_interfaces/srv/AddTwoInts")?;
+        node.create_client_untyped("/add_two_ints", "example_interfaces/srv/AddTwoInts", QosProfile::default())?;
 
     let service_available = r2r::Node::is_available(&client)?;
 

--- a/r2r/examples/untyped_client.rs
+++ b/r2r/examples/untyped_client.rs
@@ -25,8 +25,11 @@ async fn requester_task(
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
-    let client =
-        node.create_client_untyped("/add_two_ints", "example_interfaces/srv/AddTwoInts", QosProfile::default())?;
+    let client = node.create_client_untyped(
+        "/add_two_ints",
+        "example_interfaces/srv/AddTwoInts",
+        QosProfile::default(),
+    )?;
 
     let service_available = r2r::Node::is_available(&client)?;
 

--- a/r2r/examples/untyped_client.rs
+++ b/r2r/examples/untyped_client.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client =
         node.create_client_untyped("/add_two_ints", "example_interfaces/srv/AddTwoInts")?;
 
-    let service_available = node.is_available(&client)?;
+    let service_available = r2r::Node::is_available(&client)?;
 
     let mut pool = LocalPool::new();
     let spawner = pool.spawner();

--- a/r2r/examples/untyped_client.rs
+++ b/r2r/examples/untyped_client.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
-use futures::Future;
+use futures::{executor::LocalPool, task::LocalSpawnExt, Future};
 
 async fn requester_task(
     node_available: impl Future<Output = r2r::Result<()>>, c: r2r::ClientUntyped,

--- a/r2r/examples/wall_timer.rs
+++ b/r2r/examples/wall_timer.rs
@@ -1,8 +1,6 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, task::LocalSpawnExt};
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 async fn timer_task(mut t: r2r::Timer) -> Result<(), Box<dyn std::error::Error>> {
     let mut x: i32 = 0;

--- a/r2r/src/action_clients.rs
+++ b/r2r/src/action_clients.rs
@@ -1,16 +1,24 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::{FutureExt, TryFutureExt};
-use futures::stream::Stream;
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::future::Future;
-use std::mem::MaybeUninit;
-use std::sync::{Mutex, Weak};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{FutureExt, TryFutureExt},
+    stream::Stream,
+};
+use std::{
+    collections::HashMap,
+    ffi::CString,
+    future::Future,
+    mem::MaybeUninit,
+    sync::{Mutex, Weak},
+};
 
-use crate::action_common::*;
-use crate::error::*;
-use crate::msg_types::generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs};
-use crate::msg_types::*;
+use crate::{
+    action_common::*,
+    error::*,
+    msg_types::{
+        generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs},
+        *,
+    },
+};
 use r2r_actions::*;
 use r2r_rcl::*;
 

--- a/r2r/src/action_clients_untyped.rs
+++ b/r2r/src/action_clients_untyped.rs
@@ -1,16 +1,24 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::{FutureExt, TryFutureExt};
-use futures::stream::Stream;
-use std::collections::HashMap;
-use std::future::Future;
-use std::mem::MaybeUninit;
-use std::sync::{Mutex, Weak};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{FutureExt, TryFutureExt},
+    stream::Stream,
+};
+use std::{
+    collections::HashMap,
+    future::Future,
+    mem::MaybeUninit,
+    sync::{Mutex, Weak},
+};
 
-use crate::action_clients::*;
-use crate::action_common::*;
-use crate::error::*;
-use crate::msg_types::generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs};
-use crate::msg_types::*;
+use crate::{
+    action_clients::*,
+    action_common::*,
+    error::*,
+    msg_types::{
+        generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs},
+        *,
+    },
+};
 use r2r_actions::*;
 use r2r_rcl::*;
 //

--- a/r2r/src/action_servers.rs
+++ b/r2r/src/action_servers.rs
@@ -1,15 +1,22 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::FutureExt;
-use futures::future::{join_all, JoinAll};
-use futures::stream::Stream;
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::mem::MaybeUninit;
-use std::sync::{Arc, Mutex, Weak};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{join_all, FutureExt, JoinAll},
+    stream::Stream,
+};
+use std::{
+    collections::HashMap,
+    ffi::CString,
+    mem::MaybeUninit,
+    sync::{Arc, Mutex, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs};
-use crate::msg_types::*;
+use crate::{
+    error::*,
+    msg_types::{
+        generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs},
+        *,
+    },
+};
 use r2r_actions::*;
 use r2r_rcl::*;
 

--- a/r2r/src/action_servers.rs
+++ b/r2r/src/action_servers.rs
@@ -555,7 +555,7 @@ where
             // todo: add logic that replies to the requests
             self.result_requests
                 .entry(uuid)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(request_id);
         }
     }

--- a/r2r/src/clients.rs
+++ b/r2r/src/clients.rs
@@ -1,12 +1,12 @@
-use futures::channel::oneshot;
-use futures::TryFutureExt;
-use std::ffi::CString;
-use std::future::Future;
-use std::mem::MaybeUninit;
-use std::sync::{Mutex, Weak};
+use futures::{channel::oneshot, TryFutureExt};
+use std::{
+    ffi::CString,
+    future::Future,
+    mem::MaybeUninit,
+    sync::{Mutex, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::*;
+use crate::{error::*, msg_types::*};
 use r2r_rcl::*;
 
 /// ROS service client.

--- a/r2r/src/clients.rs
+++ b/r2r/src/clients.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Mutex, Weak},
 };
 
-use crate::{error::*, msg_types::*};
+use crate::{error::*, msg_types::*, QosProfile};
 use r2r_rcl::*;
 
 /// ROS service client.
@@ -319,14 +319,15 @@ impl Client_ for UntypedClient_ {
 }
 
 pub fn create_client_helper(
-    node: *mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t,
+    node: *mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t, qos_profile: QosProfile,
 ) -> Result<rcl_client_t> {
     let mut client_handle = unsafe { rcl_get_zero_initialized_client() };
     let service_name_c_string =
         CString::new(service_name).map_err(|_| Error::RCL_RET_INVALID_ARGUMENT)?;
 
     let result = unsafe {
-        let client_options = rcl_client_get_default_options();
+        let mut client_options = rcl_client_get_default_options();
+        client_options.qos = qos_profile.into();
         rcl_client_init(
             &mut client_handle,
             node,

--- a/r2r/src/clients.rs
+++ b/r2r/src/clients.rs
@@ -319,7 +319,8 @@ impl Client_ for UntypedClient_ {
 }
 
 pub fn create_client_helper(
-    node: *mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t, qos_profile: QosProfile,
+    node: *mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t,
+    qos_profile: QosProfile,
 ) -> Result<rcl_client_t> {
     let mut client_handle = unsafe { rcl_get_zero_initialized_client() };
     let service_name_c_string =

--- a/r2r/src/clocks.rs
+++ b/r2r/src/clocks.rs
@@ -1,9 +1,6 @@
-use std::fmt::Debug;
-use std::mem::MaybeUninit;
-use std::time::Duration;
+use std::{fmt::Debug, mem::MaybeUninit, time::Duration};
 
-use crate::error::*;
-use crate::msg_types::generated_msgs::builtin_interfaces;
+use crate::{error::*, msg_types::generated_msgs::builtin_interfaces};
 use r2r_rcl::*;
 
 /// Different ROS clock types.

--- a/r2r/src/clocks.rs
+++ b/r2r/src/clocks.rs
@@ -85,7 +85,7 @@ impl Clock {
     /// The clock must be [`ClockType::RosTime`].
     ///
     /// Wrapper for `rcl_enable_ros_time_override`
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub(crate) fn enable_ros_time_override(
         &mut self, initial_time: rcl_time_point_value_t,
     ) -> Result<()> {
@@ -110,7 +110,7 @@ impl Clock {
     /// The clock must be [`ClockType::RosTime`].
     ///
     /// Wrapper for `rcl_disable_ros_time_override`
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub(crate) fn disable_ros_time_override(&mut self) -> Result<()> {
         let valid = unsafe { rcl_clock_valid(&mut *self.clock_handle) };
         if !valid {
@@ -133,7 +133,7 @@ impl Clock {
     /// The clock must be [`ClockType::RosTime`].
     ///
     /// Wrapper for `rcl_set_ros_time_override`
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub(crate) fn set_ros_time_override(&mut self, time: rcl_time_point_value_t) -> Result<()> {
         let valid = unsafe { rcl_clock_valid(&mut *self.clock_handle) };
         if !valid {

--- a/r2r/src/context.rs
+++ b/r2r/src/context.rs
@@ -1,12 +1,11 @@
-use std::ffi::CStr;
-use std::ffi::CString;
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
-use std::sync::OnceLock;
-use std::sync::{Arc, Mutex};
+use std::{
+    ffi::{CStr, CString},
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex, OnceLock},
+};
 
-use crate::error::*;
-use crate::log_guard;
+use crate::{error::*, log_guard};
 use r2r_rcl::*;
 
 /// A ROS context. Needed to create nodes etc.

--- a/r2r/src/error.rs
+++ b/r2r/src/error.rs
@@ -83,6 +83,8 @@ pub enum Error {
     RCL_RET_EVENT_TAKE_FAILED,
 
     // Our own errors
+    #[error("Clock type is not RosTime")]
+    ClockTypeNotRosTime,
     #[error("No typesupport built for the message type: {}", msgtype)]
     InvalidMessageType { msgtype: String },
     #[error("Serde error: {}", err)]

--- a/r2r/src/error.rs
+++ b/r2r/src/error.rs
@@ -127,6 +127,15 @@ pub enum Error {
 
     #[error("Parameter {name} conversion failed: {msg}")]
     ParameterValueConv { name: String, msg: String },
+
+    #[error(
+        "Parameter {name} was expected to be of type {expected_type} but was of type {actual_type}"
+    )]
+    ParameterWrongType {
+        name: String,
+        expected_type: &'static str,
+        actual_type: &'static str,
+    },
 }
 
 impl Error {

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -124,6 +124,12 @@ mod nodes;
 pub use nodes::{Node, Timer};
 
 pub mod qos;
+
+#[cfg(feature = "sim-time")]
+mod time_source;
+#[cfg(feature = "sim-time")]
+pub use time_source::TimeSource;
+
 pub use qos::QosProfile;
 
 /// The ros version currently built against.

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -141,12 +141,21 @@ pub const ROS_DISTRO: &str = "foxy";
 pub const ROS_DISTRO: &str = "galactic";
 #[cfg(r2r__ros__distro__humble)]
 pub const ROS_DISTRO: &str = "humble";
+#[cfg(r2r__ros__distro__iron)]
+pub const ROS_DISTRO: &str = "iron";
+#[cfg(r2r__ros__distro__jazzy)]
+pub const ROS_DISTRO: &str = "jazzy";
+
 #[cfg(r2r__ros__distro__rolling)]
 pub const ROS_DISTRO: &str = "rolling";
+
 #[cfg(not(any(
     r2r__ros__distro__foxy,
     r2r__ros__distro__galactic,
     r2r__ros__distro__humble,
+    r2r__ros__distro__iron,
+    r2r__ros__distro__jazzy,
+
     r2r__ros__distro__rolling
 )))]
 pub const ROS_DISTRO: &str = "unknown";

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -71,8 +71,9 @@
 //! }
 //! ```
 
-// otherwise crates using r2r needs to specify the same version of uuid as
+// otherwise crates using r2r needs to specify the same version of indexmap and uuid as
 // this crate depend on, which seem like bad user experience.
+pub extern crate indexmap;
 pub extern crate uuid;
 
 mod error;

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -24,48 +24,51 @@
 //! try the following example:
 //!
 //! ``` rust
-//!use futures::executor::LocalPool;
-//!use futures::future;
-//!use futures::stream::StreamExt;
-//!use futures::task::LocalSpawnExt;
-//!use r2r::QosProfile;
+//! use futures::{executor::LocalPool, future, stream::StreamExt, task::LocalSpawnExt};
+//! use r2r::QosProfile;
 //!
-//!fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!    let ctx = r2r::Context::create()?;
-//!    let mut node = r2r::Node::create(ctx, "node", "namespace")?;
-//!    let subscriber = node.subscribe::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
-//!    let publisher = node.create_publisher::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
-//!    let mut timer = node.create_wall_timer(std::time::Duration::from_millis(1000))?;
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let ctx = r2r::Context::create()?;
+//!     let mut node = r2r::Node::create(ctx, "node", "namespace")?;
+//!     let subscriber =
+//!         node.subscribe::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
+//!     let publisher =
+//!         node.create_publisher::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
+//!     let mut timer = node.create_wall_timer(std::time::Duration::from_millis(1000))?;
 //!
-//!    // Set up a simple task executor.
-//!    let mut pool = LocalPool::new();
-//!    let spawner = pool.spawner();
+//!     // Set up a simple task executor.
+//!     let mut pool = LocalPool::new();
+//!     let spawner = pool.spawner();
 //!
-//!    // Run the subscriber in one task, printing the messages
-//!    spawner.spawn_local(async move {
-//!        subscriber.for_each(|msg| {
-//!            println!("got new msg: {}", msg.data);
-//!            future::ready(())
-//!        }).await
-//!    })?;
+//!     // Run the subscriber in one task, printing the messages
+//!     spawner.spawn_local(async move {
+//!         subscriber
+//!             .for_each(|msg| {
+//!                 println!("got new msg: {}", msg.data);
+//!                 future::ready(())
+//!             })
+//!             .await
+//!     })?;
 //!
-//!    // Run the publisher in another task
-//!    spawner.spawn_local(async move {
-//!        let mut counter = 0;
-//!        loop {
-//!            let _elapsed = timer.tick().await.unwrap();
-//!            let msg = r2r::std_msgs::msg::String { data: format!("Hello, world! ({})", counter) };
-//!            publisher.publish(&msg).unwrap();
-//!            counter += 1;
-//!        }
-//!    })?;
+//!     // Run the publisher in another task
+//!     spawner.spawn_local(async move {
+//!         let mut counter = 0;
+//!         loop {
+//!             let _elapsed = timer.tick().await.unwrap();
+//!             let msg = r2r::std_msgs::msg::String {
+//!                 data: format!("Hello, world! ({})", counter),
+//!             };
+//!             publisher.publish(&msg).unwrap();
+//!             counter += 1;
+//!         }
+//!     })?;
 //!
-//!    // Main loop spins ros.
-//!    loop {
-//!        node.spin_once(std::time::Duration::from_millis(100));
-//!        pool.run_until_stalled();
-//!    }
-//!}
+//!     // Main loop spins ros.
+//!     loop {
+//!         node.spin_once(std::time::Duration::from_millis(100));
+//!         pool.run_until_stalled();
+//!     }
+//! }
 //! ```
 
 // otherwise crates using r2r needs to specify the same version of uuid as
@@ -76,12 +79,10 @@ mod error;
 pub use error::{Error, Result};
 
 mod msg_types;
-pub use msg_types::generated_msgs::*;
-pub use msg_types::WrappedActionTypeSupport;
-pub use msg_types::WrappedNativeMsg as NativeMsg;
-pub use msg_types::WrappedNativeMsgUntyped;
-pub use msg_types::WrappedServiceTypeSupport;
-pub use msg_types::WrappedTypesupport;
+pub use msg_types::{
+    generated_msgs::*, WrappedActionTypeSupport, WrappedNativeMsg as NativeMsg,
+    WrappedNativeMsgUntyped, WrappedServiceTypeSupport, WrappedTypesupport,
+};
 
 mod utils;
 pub use utils::*;

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -125,9 +125,9 @@ pub use nodes::{Node, Timer};
 
 pub mod qos;
 
-#[cfg(feature = "sim-time")]
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 mod time_source;
-#[cfg(feature = "sim-time")]
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 pub use time_source::TimeSource;
 
 pub use qos::QosProfile;

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -115,7 +115,7 @@ mod context;
 pub use context::Context;
 
 mod parameters;
-pub use parameters::{Parameter, ParameterValue, RosParams};
+pub use parameters::{Parameter, ParameterValue, RosParams, WrongParameterType};
 
 pub use r2r_macros::RosParams;
 

--- a/r2r/src/msg_types.rs
+++ b/r2r/src/msg_types.rs
@@ -78,7 +78,7 @@ pub trait WrappedTypesupport:
 
             self.copy_to_native(unsafe { msg.as_mut().expect("not null") });
 
-            let msg_buf: &mut rcl_serialized_message_t = &mut *msg_buf
+            let msg_buf: &mut rcl_serialized_message_t = &mut msg_buf
                 .as_ref()
                 .map_err(|err| Error::from_rcl_error(*err))?
                 .borrow_mut();

--- a/r2r/src/msg_types.rs
+++ b/r2r/src/msg_types.rs
@@ -93,8 +93,12 @@ pub trait WrappedTypesupport:
                 )
             };
 
-            let data_bytes = unsafe {
-                std::slice::from_raw_parts(msg_buf.buffer, msg_buf.buffer_length).to_vec()
+            let data_bytes = if msg_buf.buffer == std::ptr::null_mut() {
+                Vec::new()
+            } else {
+                unsafe {
+                    std::slice::from_raw_parts(msg_buf.buffer, msg_buf.buffer_length).to_vec()
+                }
             };
 
             Self::destroy_msg(msg);

--- a/r2r/src/msg_types.rs
+++ b/r2r/src/msg_types.rs
@@ -5,11 +5,13 @@ use r2r_rcl::{
     rosidl_service_type_support_t,
 };
 use serde::{Deserialize, Serialize};
-use std::boxed::Box;
-use std::cell::RefCell;
-use std::convert::TryInto;
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
+use std::{
+    boxed::Box,
+    cell::RefCell,
+    convert::TryInto,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 pub mod generated_msgs {
     #![allow(clippy::all)]
@@ -551,8 +553,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::generated_msgs::*;
-    use super::*;
+    use super::{generated_msgs::*, *};
     use r2r_rcl::*;
 
     #[test]

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -39,9 +39,9 @@ pub struct Node {
     context: Context,
     /// ROS parameters.
     pub params: Arc<Mutex<HashMap<String, Parameter>>>,
-    node_handle: Box<rcl_node_t>,
+    pub(crate) node_handle: Box<rcl_node_t>,
     // the node owns the subscribers
-    subscribers: Vec<Box<dyn Subscriber_>>,
+    pub(crate) subscribers: Vec<Box<dyn Subscriber_>>,
     // services,
     services: Vec<Arc<Mutex<dyn Service_>>>,
     // service clients

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1333,6 +1333,21 @@ impl Node {
         let s = unsafe { CStr::from_ptr(ptr) };
         s.to_str().unwrap_or("")
     }
+
+    /// Get TimeSource of the node
+    ///
+    /// See: [`TimeSource`]
+    #[cfg(feature = "sim-time")]
+    pub fn get_time_source(&self) -> TimeSource {
+        self.time_source.clone()
+    }
+
+    /// Get ROS clock of the node
+    ///
+    /// This is the same clock that is used by ROS timers created in [`Node::create_timer`].
+    pub fn get_ros_clock(&self) -> Arc<Mutex<Clock>> {
+        self.ros_clock.clone()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -3,6 +3,7 @@ use futures::{
     future::{self, join_all, FutureExt, TryFutureExt},
     stream::{Stream, StreamExt},
 };
+use indexmap::IndexMap;
 use std::{
     collections::HashMap,
     ffi::{CStr, CString},
@@ -43,7 +44,7 @@ use crate::{
 pub struct Node {
     context: Context,
     /// ROS parameters.
-    pub params: Arc<Mutex<HashMap<String, Parameter>>>,
+    pub params: Arc<Mutex<IndexMap<String, Parameter>>>,
     pub(crate) node_handle: Box<rcl_node_t>,
     // the node owns the subscribers
     pub(crate) subscribers: Vec<Box<dyn Subscriber_>>,
@@ -198,7 +199,7 @@ impl Node {
             };
 
             let mut node = Node {
-                params: Arc::new(Mutex::new(HashMap::new())),
+                params: Arc::new(Mutex::new(IndexMap::new())),
                 context: ctx,
                 node_handle,
                 subscribers: Vec::new(),
@@ -460,7 +461,7 @@ impl Node {
 
     fn handle_list_parameters(
         req: ServiceRequest<rcl_interfaces::srv::ListParameters::Service>,
-        params: &Arc<Mutex<HashMap<String, Parameter>>>,
+        params: &Arc<Mutex<IndexMap<String, Parameter>>>,
     ) -> future::Ready<()> {
         use rcl_interfaces::srv::ListParameters;
 
@@ -503,7 +504,7 @@ impl Node {
 
     fn handle_desc_parameters(
         req: ServiceRequest<rcl_interfaces::srv::DescribeParameters::Service>,
-        params: &Arc<Mutex<HashMap<String, Parameter>>>,
+        params: &Arc<Mutex<IndexMap<String, Parameter>>>,
     ) -> future::Ready<()> {
         use rcl_interfaces::{msg::ParameterDescriptor, srv::DescribeParameters};
         let mut descriptors = Vec::<ParameterDescriptor>::new();

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -905,6 +905,30 @@ impl Node {
         Ok(p)
     }
 
+    /// Destroy a ROS publisher.
+    pub fn destroy_publisher<T: WrappedTypesupport>(&mut self, p: Publisher<T>) {
+        if let Some(handle) = p.handle.upgrade() {
+            // Remove handle from list of publishers.
+            self.pubs.iter().position(|p| Arc::ptr_eq(p, &handle))
+                .map(|i| self.pubs.swap_remove(i));
+
+            let handle = wait_until_unwrapped(handle);
+            handle.destroy(self.node_handle.as_mut());
+        }
+    }
+
+    /// Destroy a ROS publisher.
+    pub fn destroy_publisher_untyped(&mut self, p: PublisherUntyped) {
+        if let Some(handle) = p.handle.upgrade() {
+            // Remove handle from list of publishers.
+            self.pubs.iter().position(|p| Arc::ptr_eq(p, &handle))
+                .map(|i| self.pubs.swap_remove(i));
+
+            let handle = wait_until_unwrapped(handle);
+            handle.destroy(self.node_handle.as_mut());
+        }
+    }
+
     /// Spin the ROS node.
     ///
     /// This handles wakeups of all subscribes, services, etc on the

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1,36 +1,39 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::FutureExt;
-use futures::future::TryFutureExt;
-use futures::future::{self, join_all};
-use futures::stream::{Stream, StreamExt};
-use std::collections::HashMap;
-use std::ffi::{CStr, CString};
-use std::future::Future;
-use std::marker::PhantomPinned;
-use std::mem::MaybeUninit;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{self, join_all, FutureExt, TryFutureExt},
+    stream::{Stream, StreamExt},
+};
+use std::{
+    collections::HashMap,
+    ffi::{CStr, CString},
+    future::Future,
+    marker::PhantomPinned,
+    mem::MaybeUninit,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use r2r_actions::*;
 use r2r_rcl::*;
 
-use crate::action_clients::*;
-use crate::action_clients_untyped::*;
-use crate::action_servers::*;
-use crate::clients::*;
-use crate::clocks::*;
-use crate::context::*;
-use crate::error::*;
-use crate::msg_types::generated_msgs::rcl_interfaces;
-use crate::msg_types::*;
-use crate::parameters::*;
-use crate::publishers::*;
-use crate::qos::QosProfile;
-use crate::services::*;
-use crate::subscribers::*;
 #[cfg(r2r__rosgraph_msgs__msg__Clock)]
 use crate::time_source::TimeSource;
+use crate::{
+    action_clients::*,
+    action_clients_untyped::*,
+    action_servers::*,
+    clients::*,
+    clocks::*,
+    context::*,
+    error::*,
+    msg_types::{generated_msgs::rcl_interfaces, *},
+    parameters::*,
+    publishers::*,
+    qos::QosProfile,
+    services::*,
+    subscribers::*,
+};
 
 /// A ROS Node.
 ///
@@ -502,8 +505,7 @@ impl Node {
         req: ServiceRequest<rcl_interfaces::srv::DescribeParameters::Service>,
         params: &Arc<Mutex<HashMap<String, Parameter>>>,
     ) -> future::Ready<()> {
-        use rcl_interfaces::msg::ParameterDescriptor;
-        use rcl_interfaces::srv::DescribeParameters;
+        use rcl_interfaces::{msg::ParameterDescriptor, srv::DescribeParameters};
         let mut descriptors = Vec::<ParameterDescriptor>::new();
         let params = params.lock().unwrap();
         for name in &req.message.names {

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1239,12 +1239,17 @@ impl Node {
             let types = unsafe { std::slice::from_raw_parts(tnat.types, tnat.names.size) };
 
             for (n, t) in names.iter().zip(types) {
+                assert!(!(*n).is_null());
                 let topic_name = unsafe { CStr::from_ptr(*n).to_str().unwrap().to_owned() };
+                assert!(!t.data.is_null());
                 let topic_types = unsafe { std::slice::from_raw_parts(t, t.size) };
                 let topic_types: Vec<String> = unsafe {
                     topic_types
                         .iter()
-                        .map(|t| CStr::from_ptr(*(t.data)).to_str().unwrap().to_owned())
+                        .map(|t| {
+                            assert!(*(t.data) != std::ptr::null_mut());
+                            CStr::from_ptr(*(t.data)).to_str().unwrap().to_owned()
+                        })
                         .collect()
                 };
                 res.insert(topic_name, topic_types);

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -707,7 +707,7 @@ impl Node {
     /// `spin_once` until available, so spin_once must be called
     /// repeatedly in order to get the wakeup.
     pub fn is_available(
-        &mut self, client: &dyn IsAvailablePollable,
+        client: &dyn IsAvailablePollable,
     ) -> Result<impl Future<Output = Result<()>>> {
         let (sender, receiver) = oneshot::channel();
         client.register_poll_available(sender)?;

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -29,7 +29,7 @@ use crate::publishers::*;
 use crate::qos::QosProfile;
 use crate::services::*;
 use crate::subscribers::*;
-#[cfg(feature = "sim-time")]
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 use crate::time_source::TimeSource;
 
 /// A ROS Node.
@@ -59,7 +59,7 @@ pub struct Node {
     // RosTime clock used by all timers created by create_timer()
     ros_clock: Arc<Mutex<Clock>>,
     // time source that provides simulated time
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     time_source: TimeSource,
 }
 
@@ -187,7 +187,7 @@ impl Node {
 
         if res == RCL_RET_OK as i32 {
             let ros_clock = Arc::new(Mutex::new(Clock::create(ClockType::RosTime)?));
-            #[cfg(feature = "sim-time")]
+            #[cfg(r2r__rosgraph_msgs__msg__Clock)]
             let time_source = {
                 let time_source = TimeSource::new();
                 time_source.attach_ros_clock(Arc::downgrade(&ros_clock))?;
@@ -206,7 +206,7 @@ impl Node {
                 timers: Vec::new(),
                 pubs: Vec::new(),
                 ros_clock,
-                #[cfg(feature = "sim-time")]
+                #[cfg(r2r__rosgraph_msgs__msg__Clock)]
                 time_source,
             };
             node.load_params()?;
@@ -428,7 +428,7 @@ impl Node {
 
         handlers.push(Box::pin(get_param_types_future));
 
-        #[cfg(feature = "sim-time")]
+        #[cfg(r2r__rosgraph_msgs__msg__Clock)]
         {
             // create TimeSource based on value of use_sim_time parameter
             let use_sim_time = {
@@ -1337,7 +1337,7 @@ impl Node {
     /// Get TimeSource of the node
     ///
     /// See: [`TimeSource`]
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub fn get_time_source(&self) -> TimeSource {
         self.time_source.clone()
     }

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -277,7 +277,8 @@ impl Node {
             .create_service::<rcl_interfaces::srv::SetParameters::Service>(&format!(
                 "{}/set_parameters",
                 node_name
-            ))?;
+            ),
+            QosProfile::default())?;
 
         let params = self.params.clone();
         let params_struct_clone = params_struct.clone();
@@ -337,10 +338,9 @@ impl Node {
 
         // rcl_interfaces/srv/GetParameters
         let get_params_request_stream = self
-            .create_service::<rcl_interfaces::srv::GetParameters::Service>(&format!(
-                "{}/get_parameters",
-                node_name
-            ))?;
+            .create_service::<rcl_interfaces::srv::GetParameters::Service>(
+                &format!("{}/get_parameters",node_name),
+                QosProfile::default())?;
 
         let params = self.params.clone();
         let params_struct_clone = params_struct.clone();
@@ -379,7 +379,7 @@ impl Node {
         // rcl_interfaces/srv/ListParameters
         use rcl_interfaces::srv::ListParameters;
         let list_params_request_stream = self
-            .create_service::<ListParameters::Service>(&format!("{}/list_parameters", node_name))?;
+            .create_service::<ListParameters::Service>(&format!("{}/list_parameters", node_name), QosProfile::default())?;
 
         let params = self.params.clone();
         let list_params_future = list_params_request_stream.for_each(
@@ -393,8 +393,7 @@ impl Node {
         // rcl_interfaces/srv/DescribeParameters
         use rcl_interfaces::srv::DescribeParameters;
         let desc_params_request_stream = self.create_service::<DescribeParameters::Service>(
-            &format!("{node_name}/describe_parameters"),
-        )?;
+            &format!("{node_name}/describe_parameters"), QosProfile::default())?;
 
         let params = self.params.clone();
         let desc_params_future = desc_params_request_stream.for_each(
@@ -409,7 +408,7 @@ impl Node {
         use rcl_interfaces::srv::GetParameterTypes;
         let get_param_types_request_stream = self.create_service::<GetParameterTypes::Service>(
             &format!("{node_name}/get_parameter_types"),
-        )?;
+        QosProfile::default())?;
 
         let params = self.params.clone();
         let get_param_types_future = get_param_types_request_stream.for_each(
@@ -637,13 +636,13 @@ impl Node {
     /// This function returns a `Stream` of `ServiceRequest`:s. Call
     /// `respond` on the Service Request to send the reply.
     pub fn create_service<T: 'static>(
-        &mut self, service_name: &str,
+        &mut self, service_name: &str, qos_profile: QosProfile,
     ) -> Result<impl Stream<Item = ServiceRequest<T>> + Unpin>
     where
         T: WrappedServiceTypeSupport,
     {
         let service_handle =
-            create_service_helper(self.node_handle.as_mut(), service_name, T::get_ts())?;
+            create_service_helper(self.node_handle.as_mut(), service_name, T::get_ts(), qos_profile)?;
         let (sender, receiver) = mpsc::channel::<ServiceRequest<T>>(10);
 
         let ws = TypedService::<T> {
@@ -659,12 +658,13 @@ impl Node {
     /// Create a ROS service client.
     ///
     /// A service client is used to make requests to a ROS service server.
-    pub fn create_client<T: 'static>(&mut self, service_name: &str) -> Result<Client<T>>
+    pub fn create_client<T: 'static>(
+        &mut self, service_name: &str, qos_profile: QosProfile,) -> Result<Client<T>>
     where
         T: WrappedServiceTypeSupport,
     {
         let client_handle =
-            create_client_helper(self.node_handle.as_mut(), service_name, T::get_ts())?;
+            create_client_helper(self.node_handle.as_mut(), service_name, T::get_ts(), qos_profile)?;
         let ws = TypedClient::<T> {
             rcl_handle: client_handle,
             response_channels: Vec::new(),
@@ -684,11 +684,11 @@ impl Node {
     /// with `serde_json::Value`s instead of concrete types.  Useful
     /// when you cannot know the type of the message at compile time.
     pub fn create_client_untyped(
-        &mut self, service_name: &str, service_type: &str,
+        &mut self, service_name: &str, service_type: &str, qos_profile: QosProfile,
     ) -> Result<ClientUntyped> {
         let service_type = UntypedServiceSupport::new_from(service_type)?;
         let client_handle =
-            create_client_helper(self.node_handle.as_mut(), service_name, service_type.ts)?;
+            create_client_helper(self.node_handle.as_mut(), service_name, service_type.ts, qos_profile)?;
         let client = UntypedClient_ {
             service_type,
             rcl_handle: client_handle,

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -276,7 +276,7 @@ impl Node {
             ))?;
 
         let params = self.params.clone();
-        let params_struct_clone = params_struct.as_ref().map(|p| p.clone());
+        let params_struct_clone = params_struct.clone();
         let set_params_future = set_params_request_stream.for_each(
             move |req: ServiceRequest<rcl_interfaces::srv::SetParameters::Service>| {
                 let mut result = rcl_interfaces::srv::SetParameters::Response::default();
@@ -339,7 +339,7 @@ impl Node {
             ))?;
 
         let params = self.params.clone();
-        let params_struct_clone = params_struct.as_ref().map(|p| p.clone());
+        let params_struct_clone = params_struct.clone();
         let get_params_future = get_params_request_stream.for_each(
             move |req: ServiceRequest<rcl_interfaces::srv::GetParameters::Service>| {
                 let params = params.lock().unwrap();
@@ -350,7 +350,7 @@ impl Node {
                     .map(|n| {
                         // First try to get the parameter from the param structure
                         if let Some(ps) = &params_struct_clone {
-                            if let Ok(value) = ps.lock().unwrap().get_parameter(&n) {
+                            if let Ok(value) = ps.lock().unwrap().get_parameter(n) {
                                 return value;
                             }
                         }
@@ -481,14 +481,14 @@ impl Node {
                     return (depth == ListParameters::Request::DEPTH_RECURSIVE as u64)
                         || substr.matches(separator).count() < depth as usize;
                 }
-                return false;
+                false
             });
             get_all || prefix_matches
         }) {
             result.names.push(name.clone());
             if let Some(last_separator) = name.rfind(separator) {
                 let prefix = &name[0..last_separator];
-                if result.prefixes.iter().find(|&p| p == prefix) == None {
+                if result.prefixes.iter().all(|p| p != prefix) {
                     result.prefixes.push(prefix.to_string());
                 }
             }

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -669,7 +669,6 @@ impl Node {
 
         let ws = TypedService::<T> {
             rcl_handle: service_handle,
-            outstanding_requests: vec![],
             sender,
         };
 

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1241,7 +1241,7 @@ impl Node {
 
         let timer = Timer_ {
             timer_handle,
-            _clock: clock,
+            _clock: Some(clock),
             sender: tx,
         };
         self.timers.push(timer);
@@ -1279,7 +1279,7 @@ impl RclTimer {
 
 struct Timer_ {
     timer_handle: Pin<Box<RclTimer>>,
-    _clock: Clock, // just here to be dropped properly later.
+    _clock: Option<Clock>, // Some(clock) if the timer owns the clock, just here to be dropped properly later.
     sender: mpsc::Sender<Duration>,
 }
 

--- a/r2r/src/parameters.rs
+++ b/r2r/src/parameters.rs
@@ -34,36 +34,62 @@ impl ParameterValue {
             ParameterValue::String(string)
         } else if !v.byte_array_value.is_null() {
             let vals = unsafe {
-                std::slice::from_raw_parts((*v.byte_array_value).values, (*v.byte_array_value).size)
+                if (*v.byte_array_value).values == std::ptr::null_mut() {
+                    &[]
+                } else {
+                    std::slice::from_raw_parts(
+                        (*v.byte_array_value).values,
+                        (*v.byte_array_value).size,
+                    )
+                }
             };
             ParameterValue::ByteArray(vals.to_vec())
         } else if !v.bool_array_value.is_null() {
             let vals = unsafe {
-                std::slice::from_raw_parts((*v.bool_array_value).values, (*v.bool_array_value).size)
+                if (*v.bool_array_value).values == std::ptr::null_mut() {
+                    &[]
+                } else {
+                    std::slice::from_raw_parts(
+                        (*v.bool_array_value).values,
+                        (*v.bool_array_value).size,
+                    )
+                }
             };
             ParameterValue::BoolArray(vals.to_vec())
         } else if !v.integer_array_value.is_null() {
             let vals = unsafe {
-                std::slice::from_raw_parts(
-                    (*v.integer_array_value).values,
-                    (*v.integer_array_value).size,
-                )
+                if (*v.integer_array_value).values == std::ptr::null_mut() {
+                    &[]
+                } else {
+                    std::slice::from_raw_parts(
+                        (*v.integer_array_value).values,
+                        (*v.integer_array_value).size,
+                    )
+                }
             };
             ParameterValue::IntegerArray(vals.to_vec())
         } else if !v.double_array_value.is_null() {
             let vals = unsafe {
-                std::slice::from_raw_parts(
-                    (*v.double_array_value).values,
-                    (*v.double_array_value).size,
-                )
+                if (*v.double_array_value).values == std::ptr::null_mut() {
+                    &[]
+                } else {
+                    std::slice::from_raw_parts(
+                        (*v.double_array_value).values,
+                        (*v.double_array_value).size,
+                    )
+                }
             };
             ParameterValue::DoubleArray(vals.to_vec())
         } else if !v.string_array_value.is_null() {
             let vals = unsafe {
-                std::slice::from_raw_parts(
-                    (*v.string_array_value).data,
-                    (*v.string_array_value).size,
-                )
+                if (*v.string_array_value).data == std::ptr::null_mut() {
+                    &[]
+                } else {
+                    std::slice::from_raw_parts(
+                        (*v.string_array_value).data,
+                        (*v.string_array_value).size,
+                    )
+                }
             };
             let s = vals
                 .iter()

--- a/r2r/src/parameters.rs
+++ b/r2r/src/parameters.rs
@@ -20,7 +20,94 @@ pub enum ParameterValue {
     StringArray(Vec<String>),
 }
 
+#[derive(Debug)]
+pub struct WrongParameterType {
+    pub expected_type_name: &'static str,
+    pub actual_type_name: &'static str,
+}
+
+impl std::error::Error for WrongParameterType {}
+
+impl std::fmt::Display for WrongParameterType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "got `{}`, expected `{}`", self.actual_type_name, self.expected_type_name)
+    }
+}
+
+macro_rules! try_into_template {
+    ($ty:ty, $expected_type_name:literal, $variant:pat => $result:expr) => {
+        impl TryInto<$ty> for ParameterValue {
+            type Error = WrongParameterType;
+
+            fn try_into(self) -> std::prelude::v1::Result<$ty, Self::Error> {
+                match self {
+                    $variant => Ok($result),
+                    _ => Err(WrongParameterType {
+                        expected_type_name: $expected_type_name,
+                        actual_type_name: self.type_name(),
+                    }),
+                }
+            }
+        }
+    };
+}
+
+try_into_template!((), "not set", ParameterValue::NotSet => ());
+try_into_template!(bool, "boolean", ParameterValue::Bool(value) => value);
+try_into_template!(i64, "integer", ParameterValue::Integer(value) => value);
+try_into_template!(f64, "double", ParameterValue::Double(value) => value);
+try_into_template!(String, "string", ParameterValue::String(value) => value);
+try_into_template!(Vec<bool>, "boolean array", ParameterValue::BoolArray(value) => value);
+try_into_template!(Vec<u8>, "byte array", ParameterValue::ByteArray(value) => value);
+try_into_template!(Vec<i64>, "integer array", ParameterValue::IntegerArray(value) => value);
+try_into_template!(Vec<f64>, "double array", ParameterValue::DoubleArray(value) => value);
+try_into_template!(Vec<String>, "string array", ParameterValue::StringArray(value) => value);
+
+macro_rules! try_into_option_template {
+    ($ty:ty, $expected_type_name:literal, $variant:pat => $result:expr) => {
+        impl TryInto<Option<$ty>> for ParameterValue {
+            type Error = WrongParameterType;
+
+            fn try_into(self) -> std::prelude::v1::Result<Option<$ty>, Self::Error> {
+                match self {
+                    $variant => Ok(Some($result)),
+                    ParameterValue::NotSet => Ok(None),
+                    _ => Err(WrongParameterType {
+                        expected_type_name: $expected_type_name,
+                        actual_type_name: self.type_name(),
+                    }),
+                }
+            }
+        }
+    };
+}
+
+try_into_option_template!(bool, "boolean", ParameterValue::Bool(value) => value);
+try_into_option_template!(i64, "integer", ParameterValue::Integer(value) => value);
+try_into_option_template!(f64, "double", ParameterValue::Double(value) => value);
+try_into_option_template!(String, "string", ParameterValue::String(value) => value);
+try_into_option_template!(Vec<bool>, "boolean array", ParameterValue::BoolArray(value) => value);
+try_into_option_template!(Vec<u8>, "byte array", ParameterValue::ByteArray(value) => value);
+try_into_option_template!(Vec<i64>, "integer array", ParameterValue::IntegerArray(value) => value);
+try_into_option_template!(Vec<f64>, "double array", ParameterValue::DoubleArray(value) => value);
+try_into_option_template!(Vec<String>, "string array", ParameterValue::StringArray(value) => value);
+
 impl ParameterValue {
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            ParameterValue::NotSet => "not set",
+            ParameterValue::Bool(_) => "boolean",
+            ParameterValue::Integer(_) => "integer",
+            ParameterValue::Double(_) => "double",
+            ParameterValue::String(_) => "string",
+            ParameterValue::BoolArray(_) => "boolean array",
+            ParameterValue::ByteArray(_) => "byte array",
+            ParameterValue::IntegerArray(_) => "integer array",
+            ParameterValue::DoubleArray(_) => "double array",
+            ParameterValue::StringArray(_) => "string array",
+        }
+    }
+
     pub(crate) fn from_rcl(v: &rcl_variant_t) -> Self {
         if !v.bool_value.is_null() {
             ParameterValue::Bool(unsafe { *v.bool_value })

--- a/r2r/src/parameters.rs
+++ b/r2r/src/parameters.rs
@@ -1,7 +1,8 @@
 use crate::{Error, Result};
-use std::{collections::HashMap, ffi::CStr};
+use std::ffi::CStr;
 
 use crate::msg_types::generated_msgs::rcl_interfaces;
+use indexmap::IndexMap;
 use r2r_rcl::*;
 
 /// ROS parameter value.
@@ -190,7 +191,7 @@ impl Parameter {
 /// `parameters_derive.rs` example.
 pub trait RosParams {
     fn register_parameters(
-        &mut self, prefix: &str, param: Option<Parameter>, params: &mut HashMap<String, Parameter>,
+        &mut self, prefix: &str, param: Option<Parameter>, params: &mut IndexMap<String, Parameter>,
     ) -> Result<()>;
     fn get_parameter(&mut self, param_name: &str) -> Result<ParameterValue>;
     fn set_parameter(&mut self, param_name: &str, param_val: &ParameterValue) -> Result<()>;
@@ -202,7 +203,7 @@ macro_rules! impl_ros_params {
         impl RosParams for $type {
             fn register_parameters(
                 &mut self, prefix: &str, param: Option<Parameter>,
-                params: &mut HashMap<String, Parameter>,
+                params: &mut IndexMap<String, Parameter>,
             ) -> Result<()> {
                 if let Some(cli_param) = params.get(prefix) {
                     // Apply parameter value if set from command line or launch file

--- a/r2r/src/parameters.rs
+++ b/r2r/src/parameters.rs
@@ -209,8 +209,10 @@ macro_rules! impl_ros_params {
                     // Apply parameter value if set from command line or launch file
                     self.set_parameter("", &cli_param.value)
                         .map_err(|e| e.update_param_name(prefix))?;
+                    // Remove the parameter (will be re-inserted below with deterministic order)
+                    params.shift_remove(prefix);
                 }
-                // Insert (or replace) the parameter with filled-in description etc.
+                // Insert the parameter with filled-in description etc.
                 let mut param = param.unwrap();
                 param.value = $param_value_type($to_param_conv(self)?);
                 params.insert(prefix.to_owned(), param);

--- a/r2r/src/publishers.rs
+++ b/r2r/src/publishers.rs
@@ -1,17 +1,12 @@
-use futures::channel::oneshot;
-use futures::Future;
-use futures::TryFutureExt;
-use std::ffi::c_void;
-use std::ffi::CString;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::sync::Mutex;
-use std::sync::Once;
-use std::sync::Weak;
+use futures::{channel::oneshot, Future, TryFutureExt};
+use std::{
+    ffi::{c_void, CString},
+    fmt::Debug,
+    marker::PhantomData,
+    sync::{Mutex, Once, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::*;
-use crate::qos::QosProfile;
+use crate::{error::*, msg_types::*, qos::QosProfile};
 use r2r_rcl::*;
 
 // The publish function is thread safe. ROS2 docs state:

--- a/r2r/src/publishers.rs
+++ b/r2r/src/publishers.rs
@@ -104,7 +104,7 @@ pub struct Publisher<T>
 where
     T: WrappedTypesupport,
 {
-    handle: Weak<Publisher_>,
+    pub(crate) handle: Weak<Publisher_>,
     type_: PhantomData<T>,
 }
 
@@ -116,7 +116,7 @@ unsafe impl Send for PublisherUntyped {}
 /// move between threads.
 #[derive(Debug, Clone)]
 pub struct PublisherUntyped {
-    handle: Weak<Publisher_>,
+    pub(crate) handle: Weak<Publisher_>,
     type_: String,
 }
 

--- a/r2r/src/qos.rs
+++ b/r2r/src/qos.rs
@@ -251,7 +251,7 @@ pub enum ReliabilityPolicy {
     BestEffort,
     Reliable,
     SystemDefault,
-    #[cfg(r2r__ros__distro__iron)]
+    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
     BestAvailable,
     Unknown,
 }
@@ -267,7 +267,7 @@ impl From<ReliabilityPolicy> for rmw_qos_reliability_policy_t {
             ReliabilityPolicy::SystemDefault => {
                 rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT
             }
-            #[cfg(r2r__ros__distro__iron)]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
             ReliabilityPolicy::BestAvailable => {
                 rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE
             }
@@ -290,7 +290,7 @@ impl From<rmw_qos_reliability_policy_t> for ReliabilityPolicy {
             rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT => {
                 ReliabilityPolicy::SystemDefault
             }
-            #[cfg(r2r__ros__distro__iron)]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
             rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE => {
                 ReliabilityPolicy::BestAvailable
             }
@@ -306,7 +306,7 @@ pub enum DurabilityPolicy {
     TransientLocal,
     Volatile,
     SystemDefault,
-    #[cfg(r2r__ros__distro__iron)]
+    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
     BestAvailable,
     Unknown,
 }
@@ -323,7 +323,7 @@ impl From<DurabilityPolicy> for rmw_qos_durability_policy_t {
             DurabilityPolicy::SystemDefault => {
                 rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT
             }
-            #[cfg(r2r__ros__distro__iron)]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
             DurabilityPolicy::BestAvailable => {
                 rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE
             }
@@ -346,7 +346,7 @@ impl From<rmw_qos_durability_policy_t> for DurabilityPolicy {
             rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT => {
                 DurabilityPolicy::SystemDefault
             }
-            #[cfg(r2r__ros__distro__iron)]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
             rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE => {
                 DurabilityPolicy::BestAvailable
             }
@@ -363,7 +363,7 @@ pub enum LivelinessPolicy {
     ManualByNode,
     ManualByTopic,
     SystemDefault,
-    #[cfg(r2r__ros__distro__iron)]
+    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
     BestAvailable,
     Unknown,
 }
@@ -383,7 +383,7 @@ impl From<LivelinessPolicy> for rmw_qos_liveliness_policy_t {
             LivelinessPolicy::SystemDefault => {
                 rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT
             }
-            #[cfg(r2r__ros__distro__iron)]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
             LivelinessPolicy::BestAvailable => {
                 rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE
             }
@@ -409,7 +409,7 @@ impl From<rmw_qos_liveliness_policy_t> for LivelinessPolicy {
             rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT => {
                 LivelinessPolicy::SystemDefault
             }
-            #[cfg(r2r__ros__distro__iron)]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
             rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE => {
                 LivelinessPolicy::BestAvailable
             }

--- a/r2r/src/qos.rs
+++ b/r2r/src/qos.rs
@@ -251,7 +251,7 @@ pub enum ReliabilityPolicy {
     BestEffort,
     Reliable,
     SystemDefault,
-    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
     BestAvailable,
     Unknown,
 }
@@ -267,7 +267,7 @@ impl From<ReliabilityPolicy> for rmw_qos_reliability_policy_t {
             ReliabilityPolicy::SystemDefault => {
                 rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT
             }
-            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
             ReliabilityPolicy::BestAvailable => {
                 rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE
             }
@@ -290,7 +290,7 @@ impl From<rmw_qos_reliability_policy_t> for ReliabilityPolicy {
             rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT => {
                 ReliabilityPolicy::SystemDefault
             }
-            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
             rmw_qos_reliability_policy_t::RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE => {
                 ReliabilityPolicy::BestAvailable
             }
@@ -306,7 +306,7 @@ pub enum DurabilityPolicy {
     TransientLocal,
     Volatile,
     SystemDefault,
-    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
     BestAvailable,
     Unknown,
 }
@@ -323,7 +323,7 @@ impl From<DurabilityPolicy> for rmw_qos_durability_policy_t {
             DurabilityPolicy::SystemDefault => {
                 rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT
             }
-            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
             DurabilityPolicy::BestAvailable => {
                 rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE
             }
@@ -346,7 +346,7 @@ impl From<rmw_qos_durability_policy_t> for DurabilityPolicy {
             rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT => {
                 DurabilityPolicy::SystemDefault
             }
-            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
             rmw_qos_durability_policy_t::RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE => {
                 DurabilityPolicy::BestAvailable
             }
@@ -363,7 +363,7 @@ pub enum LivelinessPolicy {
     ManualByNode,
     ManualByTopic,
     SystemDefault,
-    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+    #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
     BestAvailable,
     Unknown,
 }
@@ -383,7 +383,7 @@ impl From<LivelinessPolicy> for rmw_qos_liveliness_policy_t {
             LivelinessPolicy::SystemDefault => {
                 rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT
             }
-            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
             LivelinessPolicy::BestAvailable => {
                 rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE
             }
@@ -409,7 +409,7 @@ impl From<rmw_qos_liveliness_policy_t> for LivelinessPolicy {
             rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT => {
                 LivelinessPolicy::SystemDefault
             }
-            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__rolling))]
+            #[cfg(any(r2r__ros__distro__iron, r2r__ros__distro__jazzy, r2r__ros__distro__rolling))]
             rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE => {
                 LivelinessPolicy::BestAvailable
             }

--- a/r2r/src/services.rs
+++ b/r2r/src/services.rs
@@ -1,4 +1,4 @@
-use futures::channel::{mpsc, oneshot};
+use futures::channel::mpsc;
 use std::{
     ffi::CString,
     mem::MaybeUninit,
@@ -57,7 +57,6 @@ where
 {
     pub rcl_handle: rcl_service_t,
     pub sender: mpsc::Sender<ServiceRequest<T>>,
-    pub outstanding_requests: Vec<oneshot::Receiver<(rmw_request_id_t, T::Response)>>,
 }
 
 impl<T: 'static> Service_ for TypedService<T>

--- a/r2r/src/services.rs
+++ b/r2r/src/services.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Mutex, Weak},
 };
 
-use crate::{error::*, msg_types::*};
+use crate::{error::*, msg_types::*, QosProfile};
 use r2r_rcl::*;
 
 /// Encapsulates a service request.
@@ -113,14 +113,15 @@ where
 }
 
 pub fn create_service_helper(
-    node: &mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t,
+    node: &mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t, qos_profile: QosProfile,
 ) -> Result<rcl_service_t> {
     let mut service_handle = unsafe { rcl_get_zero_initialized_service() };
     let service_name_c_string =
         CString::new(service_name).map_err(|_| Error::RCL_RET_INVALID_ARGUMENT)?;
 
     let result = unsafe {
-        let service_options = rcl_service_get_default_options();
+        let mut service_options = rcl_service_get_default_options();
+            service_options.qos = qos_profile.into();
         rcl_service_init(
             &mut service_handle,
             node,

--- a/r2r/src/services.rs
+++ b/r2r/src/services.rs
@@ -1,10 +1,11 @@
 use futures::channel::{mpsc, oneshot};
-use std::ffi::CString;
-use std::mem::MaybeUninit;
-use std::sync::{Arc, Mutex, Weak};
+use std::{
+    ffi::CString,
+    mem::MaybeUninit,
+    sync::{Arc, Mutex, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::*;
+use crate::{error::*, msg_types::*};
 use r2r_rcl::*;
 
 /// Encapsulates a service request.

--- a/r2r/src/services.rs
+++ b/r2r/src/services.rs
@@ -113,7 +113,8 @@ where
 }
 
 pub fn create_service_helper(
-    node: &mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t, qos_profile: QosProfile,
+    node: &mut rcl_node_t, service_name: &str, service_ts: *const rosidl_service_type_support_t,
+    qos_profile: QosProfile,
 ) -> Result<rcl_service_t> {
     let mut service_handle = unsafe { rcl_get_zero_initialized_service() };
     let service_name_c_string =
@@ -121,7 +122,7 @@ pub fn create_service_helper(
 
     let result = unsafe {
         let mut service_options = rcl_service_get_default_options();
-            service_options.qos = qos_profile.into();
+        service_options.qos = qos_profile.into();
         rcl_service_init(
             &mut service_handle,
             node,

--- a/r2r/src/subscribers.rs
+++ b/r2r/src/subscribers.rs
@@ -105,7 +105,7 @@ where
                         drop(Box::from_raw(handle_ptr));
                     } else {
                         let topic_str = rcl_subscription_get_topic_name(handle_ptr);
-                        let topic = CStr::from_ptr(topic_str);
+                        let topic = CStr::from_ptr(topic_str).to_str().expect("to_str() call failed").to_owned();
                         drop(Box::from_raw(handle_ptr));
 
                         let err_str = rcutils_get_error_string();
@@ -118,7 +118,7 @@ where
                         panic!(
                             "rcl_return_loaned_message_from_subscription() \
                             failed for subscription on topic {}: {}",
-                            topic.to_str().expect("to_str() call failed"),
+                            topic,
                             error_msg.to_str().expect("to_str() call failed")
                         );
                     }

--- a/r2r/src/subscribers.rs
+++ b/r2r/src/subscribers.rs
@@ -104,7 +104,6 @@ where
                     let handle_ptr = Box::into_raw(handle_box);
                     let ret =
                         rcl_return_loaned_message_from_subscription(handle_ptr, msg as *mut c_void);
-                    drop(Box::from_raw(handle_ptr));
                     if ret != RCL_RET_OK as i32 {
                         let err_str = rcutils_get_error_string();
                         let err_str_ptr = &(err_str.str_) as *const std::os::raw::c_char;
@@ -113,13 +112,15 @@ where
                         let topic_str = rcl_subscription_get_topic_name(handle_ptr);
                         let topic = CStr::from_ptr(topic_str);
 
-                        panic!(
+                        crate::log_error!(
+                            "r2r",
                             "rcl_return_loaned_message_from_subscription() \
                             failed for subscription on topic {}: {}",
                             topic.to_str().expect("to_str() call failed"),
                             error_msg.to_str().expect("to_str() call failed")
                         );
                     }
+                    // drop(Box::from_raw(handle_ptr));
                 });
                 WrappedNativeMsg::<T>::from_loaned(loaned_msg as *mut T::CStruct, deallocator)
             } else {

--- a/r2r/src/subscribers.rs
+++ b/r2r/src/subscribers.rs
@@ -203,8 +203,12 @@ impl Subscriber_ for RawSubscriber {
             return false;
         }
 
-        let data_bytes = unsafe {
-            std::slice::from_raw_parts(self.msg_buf.buffer, self.msg_buf.buffer_length).to_vec()
+        let data_bytes = if self.msg_buf.buffer == std::ptr::null_mut() {
+            Vec::new()
+        } else {
+            unsafe {
+                std::slice::from_raw_parts(self.msg_buf.buffer, self.msg_buf.buffer_length).to_vec()
+            }
         };
 
         if let Err(e) = self.sender.try_send(data_bytes) {

--- a/r2r/src/subscribers.rs
+++ b/r2r/src/subscribers.rs
@@ -1,12 +1,9 @@
 use futures::channel::mpsc;
 use std::ffi::CString;
 
-use crate::error::*;
-use crate::msg_types::*;
-use crate::qos::QosProfile;
+use crate::{error::*, msg_types::*, qos::QosProfile};
 use r2r_rcl::*;
-use std::ffi::c_void;
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
 
 pub trait Subscriber_ {
     fn handle(&self) -> &rcl_subscription_t;

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "sim-time")]
+#![cfg(r2r__rosgraph_msgs__msg__Clock)]
 
 use crate::builtin_interfaces::msg::Time;
 use crate::error::*;

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -1,11 +1,13 @@
 #![cfg(r2r__rosgraph_msgs__msg__Clock)]
 
-use crate::builtin_interfaces::msg::Time;
-use crate::error::*;
-use crate::msg_types::{VoidPtr, WrappedNativeMsg};
-use crate::rosgraph_msgs;
-use crate::subscribers::{create_subscription_helper, Subscriber_};
-use crate::{Clock, ClockType, Node, QosProfile, WrappedTypesupport};
+use crate::{
+    builtin_interfaces::msg::Time,
+    error::*,
+    msg_types::{VoidPtr, WrappedNativeMsg},
+    rosgraph_msgs,
+    subscribers::{create_subscription_helper, Subscriber_},
+    Clock, ClockType, Node, QosProfile, WrappedTypesupport,
+};
 use r2r_rcl::{
     rcl_node_t, rcl_subscription_fini, rcl_subscription_t, rcl_take, rcl_time_point_value_t,
     rmw_message_info_t, RCL_RET_OK,

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -1,0 +1,251 @@
+#![cfg(feature = "sim-time")]
+
+use crate::builtin_interfaces::msg::Time;
+use crate::error::*;
+use crate::msg_types::{VoidPtr, WrappedNativeMsg};
+use crate::rosgraph_msgs;
+use crate::subscribers::{create_subscription_helper, Subscriber_};
+use crate::{Clock, ClockType, Node, QosProfile, WrappedTypesupport};
+use r2r_rcl::{
+    rcl_node_t, rcl_subscription_fini, rcl_subscription_t, rcl_take, rcl_time_point_value_t,
+    rmw_message_info_t, RCL_RET_OK,
+};
+use std::sync::{Arc, Mutex, Weak};
+
+/// Provides time from `/clock` topic to attached ROS clocks
+///
+/// By default only clock used by ROS timers is attached and time from `/clock` topic is disabled.
+///
+/// The time from `/clock` topic can be activated by either of these:
+/// - calling [`TimeSource::enable_sim_time`]
+/// - having registered parameter handler and launching the node with parameter `use_sim_time:=true`
+///
+/// Similar to `rclcpp/time_source.hpp`
+#[derive(Clone)]
+pub struct TimeSource {
+    inner: Arc<Mutex<TimeSource_>>,
+}
+
+pub(crate) struct TimeSource_ {
+    managed_clocks: Vec<Weak<Mutex<Clock>>>,
+    subscriber_state: TimeSourceSubscriberState,
+    simulated_time_enabled: bool,
+    last_time_msg: rcl_time_point_value_t,
+}
+
+#[derive(Copy, Clone)]
+enum TimeSourceSubscriberState {
+    None, // subscriber does not exist
+    Active,
+    ToBeDestroyed,
+}
+
+struct TimeSourceSubscriber {
+    subscriber_handle: rcl_subscription_t,
+    time_source: TimeSource,
+}
+
+impl TimeSource {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TimeSource_::new())),
+        }
+    }
+
+    /// Attach clock of type [`RosTime`](ClockType::RosTime) to the [`TimeSource`]
+    ///
+    /// If the simulated time is enabled the [`TimeSource`] will distribute simulated time
+    /// to all attached clocks.
+    pub fn attach_ros_clock(&self, clock: Weak<Mutex<Clock>>) -> Result<()> {
+        let mut time_source = self.inner.lock().unwrap();
+        let clock_valid = clock
+            .upgrade()
+            .map(|clock_arc| {
+                let mut clock = clock_arc.lock().unwrap();
+
+                if !matches!(clock.get_clock_type(), ClockType::RosTime) {
+                    return Err(Error::ClockTypeNotRosTime);
+                }
+
+                if time_source.simulated_time_enabled {
+                    clock.enable_ros_time_override(time_source.last_time_msg)?;
+                }
+
+                Ok(())
+            })
+            .transpose()?
+            .is_some();
+        if clock_valid {
+            time_source.managed_clocks.push(clock);
+        }
+        // if upgrade is none no need to attach the clock since it is already dropped
+
+        Ok(())
+    }
+
+    /// Enables usage of simulated time
+    ///
+    /// Simulated time is provided on topic `"/clock"` in the message [rosgraph_msgs::msg::Clock].
+    pub fn enable_sim_time(&self, node: &mut Node) -> Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.simulated_time_enabled {
+            // already enabled nothing to do
+            return Ok(());
+        }
+
+        inner.simulated_time_enabled = true;
+
+        match inner.subscriber_state {
+            TimeSourceSubscriberState::None => {
+                let subscriber = TimeSourceSubscriber::new(&mut node.node_handle, self.clone())?;
+                node.subscribers.push(Box::new(subscriber));
+                inner.subscriber_state = TimeSourceSubscriberState::Active;
+            }
+            TimeSourceSubscriberState::ToBeDestroyed => {
+                inner.subscriber_state = TimeSourceSubscriberState::Active;
+            }
+            TimeSourceSubscriberState::Active => {
+                // nothing to do
+            }
+        }
+
+        let initial_time = inner.last_time_msg;
+        // enable ros time override on all attached clocks
+        inner.for_each_managed_clock(|clock| {
+            // This should never panic:
+            // This could only fail if the clock is invalid or not RosTime, but the clock is
+            // attached only if it is valid clock with type RosTime.
+            clock.enable_ros_time_override(initial_time).unwrap();
+        });
+
+        Ok(())
+    }
+
+    /// Disables usage of simulated time
+    ///
+    /// This will schedule removal of internal subscriber to the `"/clock"` topic on the next
+    /// receipt of [`rosgraph_msgs::msg::Clock`] message.
+    pub fn disable_sim_time(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.simulated_time_enabled {
+            inner.simulated_time_enabled = false;
+
+            // disable ros time override on all attached clocks
+            inner.for_each_managed_clock(|clock| {
+                // This should never panic:
+                // This could only fail if the clock is invalid or not RosTime, but the clock is
+                // attached only if it is valid clock with type RosTime.
+                clock.disable_ros_time_override().unwrap();
+            });
+        }
+
+        if matches!(inner.subscriber_state, TimeSourceSubscriberState::Active) {
+            inner.subscriber_state = TimeSourceSubscriberState::ToBeDestroyed;
+        }
+    }
+}
+
+impl TimeSource_ {
+    fn new() -> Self {
+        Self {
+            managed_clocks: vec![],
+            subscriber_state: TimeSourceSubscriberState::None,
+            simulated_time_enabled: false,
+            last_time_msg: 0,
+        }
+    }
+
+    fn for_each_managed_clock<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Clock),
+    {
+        self.managed_clocks.retain(|weak_clock| {
+            let Some(clock_arc) = weak_clock.upgrade() else {
+                // clock can be deleted
+                return false;
+            };
+
+            let mut clock = clock_arc.lock().unwrap();
+            f(&mut clock);
+
+            // retain clock
+            true
+        });
+    }
+
+    // this is similar to internal rclcpp function `set_all_clocks` in `time_source.cpp`
+    fn set_clock_time(&mut self, time_msg: Time) {
+        let time = time_msg.into();
+        self.last_time_msg = time;
+        self.for_each_managed_clock(|clock| {
+            // This should never panic:
+            // This could only fail if the clock is invalid or not RosTime, but the clock is
+            // attached only if it is valid RosTime clock.
+            clock.set_ros_time_override(time).unwrap()
+        });
+    }
+}
+
+impl TimeSourceSubscriber {
+    fn new(node_handle: &mut rcl_node_t, time_source: TimeSource) -> Result<TimeSourceSubscriber> {
+        // The values are set based on default values in rclcpp
+        let qos = QosProfile::default().keep_last(1).best_effort();
+
+        let subscriber = create_subscription_helper(
+            node_handle,
+            "/clock",
+            crate::rosgraph_msgs::msg::Clock::get_ts(),
+            qos,
+        )?;
+        Ok(Self {
+            subscriber_handle: subscriber,
+            time_source,
+        })
+    }
+}
+
+impl Subscriber_ for TimeSourceSubscriber {
+    fn handle(&self) -> &rcl_subscription_t {
+        &self.subscriber_handle
+    }
+
+    fn handle_incoming(&mut self) -> bool {
+        // update clock
+        let mut msg_info = rmw_message_info_t::default(); // we dont care for now
+        let mut clock_msg = WrappedNativeMsg::<rosgraph_msgs::msg::Clock>::new();
+        let ret = unsafe {
+            rcl_take(
+                &self.subscriber_handle,
+                clock_msg.void_ptr_mut(),
+                &mut msg_info,
+                std::ptr::null_mut(),
+            )
+        };
+
+        let mut inner_time_source = self.time_source.inner.lock().unwrap();
+        if ret == RCL_RET_OK as i32 {
+            let msg = rosgraph_msgs::msg::Clock::from_native(&clock_msg);
+
+            inner_time_source.set_clock_time(msg.clock);
+        }
+
+        match inner_time_source.subscriber_state {
+            TimeSourceSubscriberState::Active => {
+                // keep the subscriber
+                false
+            }
+            TimeSourceSubscriberState::ToBeDestroyed => {
+                inner_time_source.subscriber_state = TimeSourceSubscriberState::None;
+                // destroy the subscriber
+                true
+            }
+            TimeSourceSubscriberState::None => unreachable!(),
+        }
+    }
+
+    fn destroy(&mut self, node: &mut rcl_node_t) {
+        unsafe {
+            rcl_subscription_fini(&mut self.subscriber_handle, node);
+        }
+    }
+}

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -86,6 +86,8 @@ impl TimeSource {
     /// Enables usage of simulated time
     ///
     /// Simulated time is provided on topic `"/clock"` in the message [rosgraph_msgs::msg::Clock].
+    ///
+    /// See example: sim_time_publisher.rs
     pub fn enable_sim_time(&self, node: &mut Node) -> Result<()> {
         let mut inner = self.inner.lock().unwrap();
         if inner.simulated_time_enabled {

--- a/r2r/src/utils.rs
+++ b/r2r/src/utils.rs
@@ -139,6 +139,22 @@ macro_rules! log_fatal {
     }}
 }
 
+/// Causes compile time error if `use_sim_time` is unsupported.
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
+#[macro_export]
+macro_rules! assert_compiled_with_use_sim_time_support {
+    () => {};
+}
+
+/// Causes compile time error if `use_sim_time` is unsupported.
+#[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
+#[macro_export]
+macro_rules! assert_compiled_with_use_sim_time_support {
+    () => {
+        compile_error!("assert_compiled_with_use_sim_time_support failed: 'rosgraph_msgs' dependency is missing!");
+    };
+}
+
 #[test]
 fn test_log() {
     log_debug!("log_test", "debug msg");

--- a/r2r/src/utils.rs
+++ b/r2r/src/utils.rs
@@ -1,7 +1,11 @@
 use r2r_rcl::*;
-use std::ffi::CString;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, MutexGuard};
+use std::{
+    ffi::CString,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex, MutexGuard,
+    },
+};
 
 use lazy_static::lazy_static;
 

--- a/r2r/tests/threads.rs
+++ b/r2r/tests/threads.rs
@@ -1,5 +1,4 @@
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration};
 
 use r2r::QosProfile;
 

--- a/r2r/tests/tokio_test_raw.rs
+++ b/r2r/tests/tokio_test_raw.rs
@@ -1,6 +1,5 @@
 use futures::stream::StreamExt;
-use r2r::QosProfile;
-use r2r::WrappedTypesupport;
+use r2r::{QosProfile, WrappedTypesupport};
 use tokio::task;
 
 const N_CONCURRENT_ROS_CONTEXT: usize = 3;

--- a/r2r/tests/tokio_testing.rs
+++ b/r2r/tests/tokio_testing.rs
@@ -53,6 +53,9 @@ async fn tokio_testing() -> Result<(), Box<dyn std::error::Error>> {
                         )
                         .unwrap();
 
+                    // wait a little for publisher info to populate(?). hack to avoid CI failures.
+                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
                     let pub_info = node
                         .get_publishers_info_by_topic(&format!("/float_no_{i_context}"), false)
                         .unwrap();

--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_actions"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,12 +11,12 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.4" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.0" }
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.8.4" }
+r2r_common = { path = "../r2r_common", version = "0.9.0" }
 
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen"]

--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_actions"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,12 +11,12 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.2" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.3" }
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.2" }
+r2r_common = { path = "../r2r_common", version = "0.9.3" }
 
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen"]

--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_actions"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,12 +11,12 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.1" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.2" }
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.1" }
+r2r_common = { path = "../r2r_common", version = "0.9.2" }
 
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen"]

--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_actions"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,12 +11,12 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.3" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.4" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.4" }
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.3" }
+r2r_common = { path = "../r2r_common", version = "0.9.4" }
 
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen"]

--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_actions"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,12 +11,12 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.3" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.3" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.8.4" }
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.8.3" }
+r2r_common = { path = "../r2r_common", version = "0.8.4" }
 
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen"]

--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_actions"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,12 +11,12 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
-r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.0" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
+r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.1" }
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.0" }
+r2r_common = { path = "../r2r_common", version = "0.9.1" }
 
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen"]

--- a/r2r_actions/build.rs
+++ b/r2r_actions/build.rs
@@ -101,6 +101,7 @@ fn generate_bindings(out_file: &Path) {
 fn touch(path: &Path) {
     OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(path)
         .unwrap_or_else(|_| panic!("Unable to create file '{}'", path.display()));

--- a/r2r_actions/build.rs
+++ b/r2r_actions/build.rs
@@ -1,6 +1,8 @@
-use std::fs::OpenOptions;
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::{
+    env, fs,
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+};
 
 const BINDINGS_FILENAME: &str = "action_bindings.rs";
 

--- a/r2r_cargo.cmake
+++ b/r2r_cargo.cmake
@@ -1,5 +1,5 @@
 #
-# For r2r 0.9.1
+# For r2r 0.9.2
 #
 # cmake code for simple colcon integration.
 # See https://github.com/m-dahl/r2r_minimal_node/

--- a/r2r_cargo.cmake
+++ b/r2r_cargo.cmake
@@ -1,5 +1,5 @@
 #
-# For r2r 0.9.2
+# For r2r 0.9.3
 #
 # cmake code for simple colcon integration.
 # See https://github.com/m-dahl/r2r_minimal_node/

--- a/r2r_cargo.cmake
+++ b/r2r_cargo.cmake
@@ -1,5 +1,5 @@
 #
-# For r2r 0.9.3
+# For r2r 0.9.4
 #
 # cmake code for simple colcon integration.
 # See https://github.com/m-dahl/r2r_minimal_node/

--- a/r2r_cargo.cmake
+++ b/r2r_cargo.cmake
@@ -1,5 +1,5 @@
 #
-# For r2r 0.8.4.
+# For r2r 0.9.0
 #
 # cmake code for simple colcon integration.
 # See https://github.com/m-dahl/r2r_minimal_node/

--- a/r2r_cargo.cmake
+++ b/r2r_cargo.cmake
@@ -1,5 +1,5 @@
 #
-# For r2r 0.8.3.
+# For r2r 0.8.4.
 #
 # cmake code for simple colcon integration.
 # See https://github.com/m-dahl/r2r_minimal_node/

--- a/r2r_cargo.cmake
+++ b/r2r_cargo.cmake
@@ -1,5 +1,5 @@
 #
-# For r2r 0.9.0
+# For r2r 0.9.1
 #
 # cmake code for simple colcon integration.
 # See https://github.com/m-dahl/r2r_minimal_node/

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_common"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_common"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_common"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_common"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_common"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_common"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_common/examples/r2r_info.rs
+++ b/r2r_common/examples/r2r_info.rs
@@ -1,0 +1,44 @@
+//! Prints the environmental information for r2r.
+
+use r2r_common::RosMsg;
+
+fn main() {
+    println!("# r2r Information");
+
+    println!("## Env Hash");
+    println!("{}", r2r_common::get_env_hash());
+    println!();
+
+    println!("## Messages");
+    println!();
+    for msg in r2r_common::get_wanted_messages() {
+        let RosMsg {
+            module,
+            prefix,
+            name,
+        } = msg;
+        println!("- `{module}/{prefix}/{name}`");
+    }
+    println!();
+
+    println!("## Cargo ROS Distro");
+    println!();
+    println!("```");
+    r2r_common::print_cargo_ros_distro();
+    println!("```");
+    println!();
+
+    println!("## Cargo Link Watches");
+    println!();
+    println!("```");
+    r2r_common::print_cargo_watches();
+    println!("```");
+    println!();
+
+    println!("## Cargo Link Search");
+    println!();
+    println!("```");
+    r2r_common::print_cargo_link_search();
+    println!("```");
+    println!();
+}

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -1,11 +1,13 @@
 use os_str_bytes::RawOsString;
 use regex::*;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::env;
-use std::fs::{self, File};
-use std::io::Read;
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    env,
+    fs::{self, File},
+    io::Read,
+    path::Path,
+};
 
 #[cfg(not(feature = "doc-only"))]
 const SUPPORTED_ROS_DISTROS: &[&str] = &["foxy", "galactic", "humble", "iron", "rolling"];

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -315,7 +315,6 @@ fn get_msgs_from_package(package: &Path) -> Vec<String> {
                                 &l[7..l.len() - 4] // .idl
                             };
                             let action_name = format!("{}/action/{}", file_name_str, substr);
-                            println!("found action: {}", action_name);
                             msgs.push(action_name);
                         }
                     }

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 #[cfg(not(feature = "doc-only"))]
-const SUPPORTED_ROS_DISTROS: &[&str] = &["foxy", "galactic", "humble", "iron", "rolling"];
+const SUPPORTED_ROS_DISTROS: &[&str] = &["foxy", "galactic", "humble", "iron", "jazzy", "rolling"];
 
 const WATCHED_ENV_VARS: &[&str] = &[
     "AMENT_PREFIX_PATH",

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -157,13 +157,13 @@ pub fn print_cargo_used_cfgs(_message_cfgs: &[&str]) {}
 pub fn print_cargo_used_cfgs(message_cfgs: &[&str]) {
     // Declare all supported ros distros as cfg directives for cargo
     for d in SUPPORTED_ROS_DISTROS {
-        println!("cargo::rustc-check-cfg=cfg(r2r__ros__distro__{d})");
+        println!("cargo:rustc-check-cfg=cfg(r2r__ros__distro__{d})");
     }
 
     // additionally we have conditional tests and features based on some
     // optional ros message packages.
     for c in message_cfgs {
-        println!("cargo::rustc-check-cfg=cfg({c})");
+        println!("cargo:rustc-check-cfg=cfg({c})");
     }
 }
 

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -150,6 +150,10 @@ pub fn print_cargo_ros_distro() {
     }
 }
 
+#[cfg(feature = "doc-only")]
+pub fn print_cargo_used_cfgs(_message_cfgs: &[&str]) {}
+
+#[cfg(not(feature = "doc-only"))]
 pub fn print_cargo_used_cfgs(message_cfgs: &[&str]) {
     // Declare all supported ros distros as cfg directives for cargo
     for d in SUPPORTED_ROS_DISTROS {

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -150,6 +150,19 @@ pub fn print_cargo_ros_distro() {
     }
 }
 
+pub fn print_cargo_used_cfgs(message_cfgs: &[&str]) {
+    // Declare all supported ros distros as cfg directives for cargo
+    for d in SUPPORTED_ROS_DISTROS {
+        println!("cargo::rustc-check-cfg=cfg(r2r__ros__distro__{d})");
+    }
+
+    // additionally we have conditional tests and features based on some
+    // optional ros message packages.
+    for c in message_cfgs {
+        println!("cargo::rustc-check-cfg=cfg({c})");
+    }
+}
+
 pub fn print_cargo_link_search() {
     let ament_prefix_var_name = "AMENT_PREFIX_PATH";
     if let Some(paths) = env::var_os(ament_prefix_var_name) {

--- a/r2r_macros/Cargo.toml
+++ b/r2r_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_macros"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_macros/Cargo.toml
+++ b/r2r_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_macros"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_macros/Cargo.toml
+++ b/r2r_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_macros"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_macros/Cargo.toml
+++ b/r2r_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_macros"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_macros/Cargo.toml
+++ b/r2r_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_macros"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_macros/Cargo.toml
+++ b/r2r_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_macros"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "MIT"

--- a/r2r_macros/src/lib.rs
+++ b/r2r_macros/src/lib.rs
@@ -26,7 +26,7 @@ pub fn derive_r2r_params(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                 &mut self,
                 prefix: &str,
                 desc: ::std::option::Option<::r2r::Parameter>,
-                params: &mut ::std::collections::hash_map::HashMap<String, ::r2r::Parameter>,
+                params: &mut ::r2r::indexmap::IndexMap<String, ::r2r::Parameter>,
             ) -> ::r2r::Result<()> {
                 let prefix = if prefix.is_empty() {
                     String::from("")

--- a/r2r_macros/src/lib.rs
+++ b/r2r_macros/src/lib.rs
@@ -1,7 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::spanned::Spanned;
-use syn::{parse_macro_input, Data, DeriveInput, Fields};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
 
 extern crate proc_macro;
 

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_msg_gen"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
-r2r_common = { path = "../r2r_common", version = "0.9.0" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
+r2r_common = { path = "../r2r_common", version = "0.9.1" }
 phf = { version = "0.11.1", features = ["macros"] }
 quote = "1.0.28"
 proc-macro2 = "1.0.60"
@@ -22,8 +22,8 @@ rayon = "1.7.0"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
-r2r_common = { path = "../r2r_common", version = "0.9.0" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
+r2r_common = { path = "../r2r_common", version = "0.9.1" }
 quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }
 rayon = "1.7.0"

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_msg_gen"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
-r2r_common = { path = "../r2r_common", version = "0.8.4" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
+r2r_common = { path = "../r2r_common", version = "0.9.0" }
 phf = { version = "0.11.1", features = ["macros"] }
 quote = "1.0.28"
 proc-macro2 = "1.0.60"
@@ -22,8 +22,8 @@ rayon = "1.7.0"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
-r2r_common = { path = "../r2r_common", version = "0.8.4" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.0" }
+r2r_common = { path = "../r2r_common", version = "0.9.0" }
 quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }
 rayon = "1.7.0"

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_msg_gen"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
-r2r_common = { path = "../r2r_common", version = "0.9.3" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.4" }
+r2r_common = { path = "../r2r_common", version = "0.9.4" }
 phf = { version = "0.11.1", features = ["macros"] }
 quote = "1.0.28"
 proc-macro2 = "1.0.60"
@@ -22,8 +22,8 @@ rayon = "1.7.0"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
-r2r_common = { path = "../r2r_common", version = "0.9.3" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.4" }
+r2r_common = { path = "../r2r_common", version = "0.9.4" }
 quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }
 rayon = "1.7.0"

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_msg_gen"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
-r2r_common = { path = "../r2r_common", version = "0.9.1" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
+r2r_common = { path = "../r2r_common", version = "0.9.2" }
 phf = { version = "0.11.1", features = ["macros"] }
 quote = "1.0.28"
 proc-macro2 = "1.0.60"
@@ -22,8 +22,8 @@ rayon = "1.7.0"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.1" }
-r2r_common = { path = "../r2r_common", version = "0.9.1" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
+r2r_common = { path = "../r2r_common", version = "0.9.2" }
 quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }
 rayon = "1.7.0"

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_msg_gen"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.3" }
-r2r_common = { path = "../r2r_common", version = "0.8.3" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
+r2r_common = { path = "../r2r_common", version = "0.8.4" }
 phf = { version = "0.11.1", features = ["macros"] }
 quote = "1.0.28"
 proc-macro2 = "1.0.60"
@@ -22,8 +22,8 @@ rayon = "1.7.0"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_rcl = { path = "../r2r_rcl", version = "0.8.3" }
-r2r_common = { path = "../r2r_common", version = "0.8.3" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.8.4" }
+r2r_common = { path = "../r2r_common", version = "0.8.4" }
 quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }
 rayon = "1.7.0"

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_msg_gen"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -11,8 +11,8 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
-r2r_common = { path = "../r2r_common", version = "0.9.2" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
+r2r_common = { path = "../r2r_common", version = "0.9.3" }
 phf = { version = "0.11.1", features = ["macros"] }
 quote = "1.0.28"
 proc-macro2 = "1.0.60"
@@ -22,8 +22,8 @@ rayon = "1.7.0"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_rcl = { path = "../r2r_rcl", version = "0.9.2" }
-r2r_common = { path = "../r2r_common", version = "0.9.2" }
+r2r_rcl = { path = "../r2r_rcl", version = "0.9.3" }
+r2r_common = { path = "../r2r_common", version = "0.9.3" }
 quote = "1.0.28"
 syn = { version = "2.0.18", features = ["full"] }
 rayon = "1.7.0"

--- a/r2r_msg_gen/build.rs
+++ b/r2r_msg_gen/build.rs
@@ -1,19 +1,15 @@
 use bindgen::Bindings;
-use itertools::chain;
-use itertools::iproduct;
-use itertools::Either;
-use itertools::Itertools;
-use quote::format_ident;
-use quote::quote;
+use itertools::{chain, iproduct, Either, Itertools};
+use quote::{format_ident, quote};
 use r2r_common::{camel_to_snake, RosMsg};
 use rayon::prelude::*;
-use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::prelude::*;
-use std::io::BufWriter;
-use std::mem;
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::{
+    env, fs,
+    fs::{File, OpenOptions},
+    io::{prelude::*, BufWriter},
+    mem,
+    path::{Path, PathBuf},
+};
 
 const MSG_INCLUDES_FILENAME: &str = "msg_includes.h";
 const INTROSPECTION_FILENAME: &str = "introspection_functions.rs";

--- a/r2r_msg_gen/build.rs
+++ b/r2r_msg_gen/build.rs
@@ -115,7 +115,7 @@ fn generate_includes(bindgen_dir: &Path, msg_list: &[RosMsg]) {
             } = msg;
 
             // filename is certainly CamelCase -> snake_case. convert
-            let include_filename = camel_to_snake(&name);
+            let include_filename = camel_to_snake(name);
 
             [
                 format!("#include <{module}/{prefix}/{include_filename}.h>"),
@@ -131,7 +131,7 @@ fn generate_includes(bindgen_dir: &Path, msg_list: &[RosMsg]) {
     include_lines.par_sort();
 
     // Write the file content
-    let mut writer = BufWriter::new(File::create(&msg_includes_file).unwrap());
+    let mut writer = BufWriter::new(File::create(msg_includes_file).unwrap());
     for line in include_lines {
         writeln!(writer, "{line}").unwrap();
     }
@@ -163,7 +163,6 @@ fn generate_introspecion_map(bindgen_dir: &Path, msg_list: &[RosMsg]) {
                         );
                         (key, ident)
                     })
-                    .map(|(key, ident)| (key, ident))
                     .collect(),
                 "action" => {
                     let iter1 = ACTION_SUFFICES.iter().map(|s| {
@@ -551,6 +550,7 @@ fn run_dynlink(msg_list: &[RosMsg]) {
 fn touch(path: &Path) {
     OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(path)
         .unwrap_or_else(|_| panic!("Unable to create file '{}'", path.display()));

--- a/r2r_msg_gen/src/introspection.rs
+++ b/r2r_msg_gen/src/introspection.rs
@@ -1,13 +1,14 @@
-use crate::rosidl_message_type_support_t as CTypeSupport;
-use crate::rosidl_typesupport_introspection_c__MessageMember as CMessageMember;
-use crate::rosidl_typesupport_introspection_c__MessageMembers as CMessageMembers;
-use crate::rust_mangle;
+use crate::{
+    rosidl_message_type_support_t as CTypeSupport,
+    rosidl_typesupport_introspection_c__MessageMember as CMessageMember,
+    rosidl_typesupport_introspection_c__MessageMembers as CMessageMembers, rust_mangle,
+};
 use quote::quote;
-use std::borrow::Cow;
-use std::ffi::c_char;
-use std::ffi::CStr;
-use std::mem;
-use std::slice;
+use std::{
+    borrow::Cow,
+    ffi::{c_char, CStr},
+    mem, slice,
+};
 
 pub struct Introspection<'a> {
     pub module: &'a str,

--- a/r2r_msg_gen/src/introspection.rs
+++ b/r2r_msg_gen/src/introspection.rs
@@ -234,7 +234,7 @@ impl MemberType {
             MemberType::F32 => quote! { f32 },
             MemberType::F64 => quote! { f64 },
             MemberType::Char => quote! { std::ffi::c_char },
-            MemberType::WChar => quote! { widestring::WideChar },
+            MemberType::WChar => quote! { u16 },
             MemberType::String => quote! { std::string::String },
             MemberType::WString => quote! { std::string::String },
             MemberType::Message => quote! { message },

--- a/r2r_msg_gen/src/lib.rs
+++ b/r2r_msg_gen/src/lib.rs
@@ -446,14 +446,16 @@ pub fn generate_rust_msg(module_: &str, prefix_: &str, name_: &str) -> proc_macr
                         quote! {
                             #field_name : {
                                 let mut temp = Vec::with_capacity(msg. #field_name .size);
-                                let slice = unsafe {
-                                    std::slice::from_raw_parts(
-                                        msg. #field_name .data,
-                                        msg. #field_name .size
-                                    )
-                                };
-                                for s in slice {
-                                    temp.push( #module :: #prefix :: #name :: from_native(s));
+                                if msg. #field_name .data != std::ptr::null_mut() {
+                                    let slice = unsafe {
+                                        std::slice::from_raw_parts(
+                                            msg. #field_name .data,
+                                            msg. #field_name .size
+                                        )
+                                    };
+                                    for s in slice {
+                                        temp.push( #module :: #prefix :: #name :: from_native(s));
+                                    }
                                 }
                                 temp
                             },
@@ -589,9 +591,11 @@ pub fn generate_rust_msg(module_: &str, prefix_: &str, name_: &str) -> proc_macr
                                 #fini_func (&mut msg. #field_name);
                                 #init_func (&mut msg. #field_name , self. #field_name .len());
 
-                                let slice = std::slice::from_raw_parts_mut(msg. #field_name .data, msg. #field_name .size);
-                                for (t, s) in slice.iter_mut().zip(&self. #field_name ) {
-                                    s.copy_to_native(t);
+                                if msg. #field_name .data != std::ptr::null_mut() {
+                                    let slice = std::slice::from_raw_parts_mut(msg. #field_name .data, msg. #field_name .size);
+                                    for (t, s) in slice.iter_mut().zip(&self. #field_name ) {
+                                        s.copy_to_native(t);
+                                    }
                                 }
                             }
                         }

--- a/r2r_msg_gen/src/lib.rs
+++ b/r2r_msg_gen/src/lib.rs
@@ -23,13 +23,11 @@ use {
     std::mem,
 };
 
-use quote::format_ident;
-use quote::quote;
+use quote::{format_ident, quote};
 use r2r_common::RosMsg;
 use r2r_rcl::*;
 
-use std::borrow::Cow;
-use std::ffi::CStr;
+use std::{borrow::Cow, ffi::CStr};
 
 use std::slice;
 

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_rcl"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -16,7 +16,7 @@ widestring = "1.0.2"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.1" }
+r2r_common = { path = "../r2r_common", version = "0.9.2" }
 
 [features]
 save-bindgen = []

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_rcl"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -16,7 +16,7 @@ widestring = "1.0.2"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.3" }
+r2r_common = { path = "../r2r_common", version = "0.9.4" }
 
 [features]
 save-bindgen = []

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_rcl"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -16,7 +16,7 @@ widestring = "1.0.2"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.8.4" }
+r2r_common = { path = "../r2r_common", version = "0.9.0" }
 
 [features]
 save-bindgen = []

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_rcl"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -16,7 +16,7 @@ widestring = "1.0.2"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.2" }
+r2r_common = { path = "../r2r_common", version = "0.9.3" }
 
 [features]
 save-bindgen = []

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_rcl"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -16,7 +16,7 @@ widestring = "1.0.2"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.8.3" }
+r2r_common = { path = "../r2r_common", version = "0.8.4" }
 
 [features]
 save-bindgen = []

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2r_rcl"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Internal dependency to the r2r crate."
 license = "MIT"
@@ -16,7 +16,7 @@ widestring = "1.0.2"
 
 [build-dependencies]
 bindgen = "0.63.0"
-r2r_common = { path = "../r2r_common", version = "0.9.0" }
+r2r_common = { path = "../r2r_common", version = "0.9.1" }
 
 [features]
 save-bindgen = []

--- a/r2r_rcl/build.rs
+++ b/r2r_rcl/build.rs
@@ -1,8 +1,8 @@
-use std::env;
-use std::fs;
-use std::fs::OpenOptions;
-use std::path::Path;
-use std::path::PathBuf;
+use std::{
+    env, fs,
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+};
 
 fn main() {
     r2r_common::print_cargo_watches();

--- a/r2r_rcl/build.rs
+++ b/r2r_rcl/build.rs
@@ -107,6 +107,7 @@ fn gen_bindings(out_file: &Path) {
 fn touch(path: &Path) {
     OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(path)
         .unwrap_or_else(|_| panic!("Unable to create file '{}'", path.display()));

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -56,13 +56,18 @@ impl rosidl_runtime_c__U16String__Sequence {
         unsafe {
             rosidl_runtime_c__U16String__Sequence__init(self as *mut _, values.len());
         }
-        let strs = unsafe { std::slice::from_raw_parts_mut(self.data, values.len()) };
-        for (target, source) in strs.iter_mut().zip(values) {
-            target.assign(source);
+        if self.data != std::ptr::null_mut() {
+            let strs = unsafe { std::slice::from_raw_parts_mut(self.data, values.len()) };
+            for (target, source) in strs.iter_mut().zip(values) {
+                target.assign(source);
+            }
         }
     }
 
     pub fn to_vec(&self) -> Vec<String> {
+        if self.data == std::ptr::null_mut() {
+            return Vec::new();
+        }
         let mut target = Vec::with_capacity(self.size);
         let strs = unsafe { std::slice::from_raw_parts(self.data, self.size) };
         for s in strs {
@@ -80,13 +85,18 @@ impl rosidl_runtime_c__String__Sequence {
         unsafe {
             rosidl_runtime_c__String__Sequence__init(self as *mut _, values.len());
         }
-        let strs = unsafe { std::slice::from_raw_parts_mut(self.data, values.len()) };
-        for (target, source) in strs.iter_mut().zip(values) {
-            target.assign(source);
+        if self.data != std::ptr::null_mut() {
+            let strs = unsafe { std::slice::from_raw_parts_mut(self.data, values.len()) };
+            for (target, source) in strs.iter_mut().zip(values) {
+                target.assign(source);
+            }
         }
     }
 
     pub fn to_vec(&self) -> Vec<String> {
+        if self.data == std::ptr::null_mut() {
+            return Vec::new();
+        }
         let mut target = Vec::with_capacity(self.size);
         let strs = unsafe { std::slice::from_raw_parts(self.data, self.size) };
         for s in strs {
@@ -105,10 +115,15 @@ macro_rules! primitive_sequence {
                 pub fn update(&mut self, values: &[$element_type]) {
                     unsafe { [<$ctype __Sequence__fini>] (self as *mut _); }
                     unsafe { [<$ctype __Sequence__init>] (self as *mut _, values.len()); }
-                    unsafe { std::ptr::copy(values.as_ptr(), self.data, values.len()); }
+                    if self.data != std::ptr::null_mut() {
+                        unsafe { std::ptr::copy(values.as_ptr(), self.data, values.len()); }
+                    }
                 }
 
                 pub fn to_vec(&self) -> Vec<$element_type> {
+                    if self.data == std::ptr::null_mut() {
+                        return Vec::new();
+                    }
                     let mut target = Vec::with_capacity(self.size);
                     unsafe {
                         std::ptr::copy(self.data, target.as_mut_ptr(), self.size);

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![allow(improper_ctypes)]
 #![allow(dead_code)]
 // Silence "`extern` fn uses type `u128`, which is not FFI-safe"
 // As of rustc 1.78, this has been fixed.
 // It could be good to still warn if building with an older rust version.
 #![allow(improper_ctypes)]
+#![allow(improper_ctypes_definitions)]
 include!(concat!(env!("OUT_DIR"), "/rcl_bindings.rs"));
 
 use std::ffi::{CStr, CString};

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -116,7 +116,7 @@ macro_rules! primitive_sequence {
                     unsafe { [<$ctype __Sequence__fini>] (self as *mut _); }
                     unsafe { [<$ctype __Sequence__init>] (self as *mut _, values.len()); }
                     if self.data != std::ptr::null_mut() {
-                        unsafe { std::ptr::copy(values.as_ptr(), self.data, values.len()); }
+                        unsafe { std::ptr::copy_nonoverlapping(values.as_ptr(), self.data, values.len()); }
                     }
                 }
 
@@ -126,7 +126,7 @@ macro_rules! primitive_sequence {
                     }
                     let mut target = Vec::with_capacity(self.size);
                     unsafe {
-                        std::ptr::copy(self.data, target.as_mut_ptr(), self.size);
+                        std::ptr::copy_nonoverlapping(self.data, target.as_mut_ptr(), self.size);
                         target.set_len(self.size);
                     }
                     target

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -3,6 +3,10 @@
 #![allow(non_snake_case)]
 #![allow(improper_ctypes)]
 #![allow(dead_code)]
+// Silence "`extern` fn uses type `u128`, which is not FFI-safe"
+// As of rustc 1.78, this has been fixed.
+// It could be good to still warn if building with an older rust version.
+#![allow(improper_ctypes)]
 include!(concat!(env!("OUT_DIR"), "/rcl_bindings.rs"));
 
 use std::ffi::{CStr, CString};

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -5,8 +5,7 @@
 #![allow(dead_code)]
 include!(concat!(env!("OUT_DIR"), "/rcl_bindings.rs"));
 
-use std::ffi::CStr;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 
 impl Default for rmw_message_info_t {
     fn default() -> Self {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,9 @@
+edition = "2021"
 hard_tabs = false
 tab_spaces = 4
 reorder_imports = true
 newline_style = "Unix"
 fn_call_width = 80
 fn_params_layout = "Compressed"
+imports_granularity = "Crate"
+format_code_in_doc_comments = true

--- a/tests/Dockerfile_jazzy
+++ b/tests/Dockerfile_jazzy
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM ros:jazzy
+
+# Update default packages
+RUN apt-get update
+
+# Get Ubuntu packages
+RUN apt-get install -y \
+    build-essential \
+    curl \
+    libclang-dev
+
+# Get ros test messages
+RUN apt-get install -y ros-jazzy-test-msgs ros-jazzy-example-interfaces
+
+# Get Rust
+RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | bash -s -- -y
+RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+
+COPY . /r2r
+RUN chmod +x /r2r/tests/test.bash
+ENTRYPOINT [ "/r2r/tests/test.bash" ]

--- a/tests/build_minimal_node.bash
+++ b/tests/build_minimal_node.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Use the local version of r2r when building the minimal node.
+rm /r2r/r2r_minimal_node/r2r_minimal_node/Cargo.lock
 cat >> /r2r/r2r_minimal_node/r2r_minimal_node/Cargo.toml << EOF
 
 [patch.crates-io]

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -5,7 +5,9 @@
 # run rustup to test with latest rust version
 rustup update
 
-if [ -e "/opt/ros/iron/setup.bash" ]; then
+if [ -e "/opt/ros/jazzy/setup.bash" ]; then
+    source "/opt/ros/jazzy/setup.bash"
+elif [ -e "/opt/ros/iron/setup.bash" ]; then
     source "/opt/ros/iron/setup.bash"
 elif [ -e "/opt/ros/humble/setup.bash" ]; then
     source "/opt/ros/humble/setup.bash"

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -5,10 +5,6 @@
 # run rustup to test with latest rust version
 rustup update
 
-# temporary fix for CI until #96 is resolved
-rustup toolchain install 1.77
-rustup default 1.77
-
 if [ -e "/opt/ros/iron/setup.bash" ]; then
     source "/opt/ros/iron/setup.bash"
 elif [ -e "/opt/ros/humble/setup.bash" ]; then

--- a/tests/test.bash
+++ b/tests/test.bash
@@ -5,6 +5,10 @@
 # run rustup to test with latest rust version
 rustup update
 
+# temporary fix for CI until #96 is resolved
+rustup toolchain install 1.77
+rustup default 1.77
+
 if [ -e "/opt/ros/iron/setup.bash" ]; then
     source "/opt/ros/iron/setup.bash"
 elif [ -e "/opt/ros/humble/setup.bash" ]; then


### PR DESCRIPTION
Simulated time can be enabled:

- Implicitly, by registering a parameter handler. While launching the node, parameter `use_sim_time` must be set to `true`.
- Explicitly, by calling `TimeSource::enable_sim_time(&self)`.



It works but needs more polishing.